### PR TITLE
feat: Add Privacy Policy and Terms of Service pages

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -5,6 +5,7 @@
       "firebase.json",
       "**/.*",
       "**/node_modules/**"
-    ]
+    ],
+    "cleanUrls": true
   }
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,6 +6,7 @@ import { useState, useEffect } from 'react'; // Import useState and useEffect
 import { Label } from "@/components/ui/label"; // Import Label
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"; // Import Select components
 import { TrendingUp, ExternalLink, Award } from 'lucide-react';
+import Link from 'next/link';
 import CurrentRateDisplay from '@/components/current-rate-display';
 import HistoryChartDisplay from '@/components/history-chart-display';
 import AnalysisDisplay from '@/components/analysis-display';
@@ -194,7 +195,16 @@ const UsdThbMonitorPage: FC = () => {
             ))}
           </div>
         </div>
-        <p className="text-xs text-muted-foreground text-center mt-6">
+        <div className="flex justify-center gap-4 mt-6">
+          <Link href="/privacy" className="text-xs text-muted-foreground hover:text-primary transition-colors">
+            Privacy Policy
+          </Link>
+          <span className="text-xs text-muted-foreground">•</span>
+          <Link href="/terms" className="text-xs text-muted-foreground hover:text-primary transition-colors">
+            Terms of Service
+          </Link>
+        </div>
+        <p className="text-xs text-muted-foreground text-center mt-4">
           Application developed by Nuttapong Buttprom using Firebase Studio.
         </p>
       </footer>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -204,7 +204,7 @@ const UsdThbMonitorPage: FC = () => {
             Terms of Service
           </Link>
         </div>
-        <p className="text-xs text-muted-foreground text-center mt-4">
+        <p className="text-xs text-muted-foreground text-center mt-6">
           Application developed by Nuttapong Buttprom using Firebase Studio.
         </p>
       </footer>

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,0 +1,195 @@
+import Link from 'next/link';
+import { Home } from 'lucide-react';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Privacy Policy - FX Alert',
+  description: 'Learn how FX Alert collects, uses, and protects your data. We do not collect personal information.',
+};
+
+export default function PrivacyPolicyPage() {
+  return (
+    <div className="min-h-screen bg-background text-foreground flex flex-col items-center p-4 sm:p-6">
+      <div className="w-full max-w-4xl">
+        {/* Back to Home Link */}
+        <Link
+          href="/"
+          className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-primary mb-6 transition-colors"
+        >
+          <Home className="w-4 h-4" />
+          Back to FX Alert
+        </Link>
+
+        {/* Header */}
+        <header className="mb-8">
+          <h1 className="text-3xl sm:text-4xl font-bold text-primary mb-2">
+            Privacy Policy
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            Last updated: March 10, 2026
+          </p>
+        </header>
+
+        {/* Content */}
+        <main className="space-y-6">
+          <section>
+            <h2 className="text-lg font-semibold text-foreground mb-2">Introduction</h2>
+            <p className="text-sm text-muted-foreground leading-relaxed">
+              FX Alert (&quot;we,&quot; &quot;our,&quot; or &quot;us&quot;) is committed to protecting your privacy.
+              This Privacy Policy explains how we collect, use, and disclose information about you when you use our website.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-foreground mb-2">Information We Collect</h2>
+            <div className="space-y-3">
+              <div>
+                <h3 className="text-sm font-medium text-foreground mb-1">Automatically Collected Information</h3>
+                <p className="text-sm text-muted-foreground leading-relaxed">
+                  We use Google Analytics to collect anonymous usage data, including:
+                </p>
+                <ul className="text-xs text-muted-foreground mt-2 space-y-1 list-disc list-inside">
+                  <li>Browser type and version</li>
+                  <li>Operating system</li>
+                  <li>Referring website</li>
+                  <li>Pages visited and time spent on pages</li>
+                  <li>IP address (anonymized)</li>
+                </ul>
+              </div>
+
+              <div>
+                <h3 className="text-sm font-medium text-foreground mb-1">Cookies and Local Storage</h3>
+                <p className="text-sm text-muted-foreground leading-relaxed">
+                  We use browser cookies and local storage to:
+                </p>
+                <ul className="text-xs text-muted-foreground mt-2 space-y-1 list-disc list-inside">
+                  <li>Remember your currency preferences</li>
+                  <li>Remember your selected analysis period</li>
+                  <li>Remember your alert threshold settings</li>
+                  <li>Analyze site traffic and usage patterns</li>
+                </ul>
+              </div>
+
+              <div>
+                <h3 className="text-sm font-medium text-foreground mb-1">Personal Data</h3>
+                <p className="text-sm text-muted-foreground leading-relaxed">
+                  <strong>We do not collect personal identifiable information (PII)</strong> such as:
+                </p>
+                <ul className="text-xs text-muted-foreground mt-2 space-y-1 list-disc list-inside">
+                  <li>Names</li>
+                  <li>Email addresses</li>
+                  <li>Phone numbers</li>
+                  <li>Physical addresses</li>
+                  <li>Financial account information</li>
+                </ul>
+              </div>
+            </div>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-foreground mb-2">How We Use Your Information</h2>
+            <p className="text-sm text-muted-foreground leading-relaxed">
+              We use the collected information to:
+            </p>
+            <ul className="text-xs text-muted-foreground mt-2 space-y-1 list-disc list-inside">
+              <li>Improve and maintain our service</li>
+              <li>Analyze usage patterns and user behavior</li>
+              <li>Diagnose technical issues</li>
+              <li>Understand which features are most popular</li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-foreground mb-2">Third-Party Services</h2>
+            <p className="text-sm text-muted-foreground leading-relaxed">
+              Our website integrates with the following third-party services:
+            </p>
+            <ul className="text-xs text-muted-foreground mt-2 space-y-2 list-disc list-inside">
+              <li>
+                <strong className="text-foreground">Frankfurter API</strong> — Provides current and historical exchange rate data.
+                They may collect anonymous usage statistics. See their privacy policy at{' '}
+                <a href="https://frankfurter.app" target="_blank" rel="noopener noreferrer" className="text-primary hover:underline">
+                  frankfurter.app
+                </a>.
+              </li>
+              <li>
+                <strong className="text-foreground">Google Analytics</strong> — Analytics service provided by Google LLC.
+                Google may use the collected data to contextualize and personalize the ads of its own advertising network.
+                You can opt-out of Google Analytics by installing the{' '}
+                <a href="https://tools.google.com/dlpage/gaoptout" target="_blank" rel="noopener noreferrer" className="text-primary hover:underline">
+                  Google Analytics Opt-out Browser Add-on
+                </a>.
+              </li>
+              <li>
+                <strong className="text-foreground">Firebase Hosting</strong> — Our website is hosted on Google Firebase.
+                See Google&apos;s privacy policy at{' '}
+                <a href="https://policies.google.com/privacy" target="_blank" rel="noopener noreferrer" className="text-primary hover:underline">
+                  policies.google.com/privacy
+                </a>.
+              </li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-foreground mb-2">Data Sharing and Disclosure</h2>
+            <p className="text-sm text-muted-foreground leading-relaxed">
+              <strong>We do not sell, trade, or rent your personal identification information to others.</strong>
+              We may share anonymous aggregated data with third parties for the purposes described above.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-foreground mb-2">Your Rights and Choices</h2>
+            <p className="text-sm text-muted-foreground leading-relaxed">
+              Since we do not collect personal information, you do not need to request account deletion or data export.
+              However, you can:
+            </p>
+            <ul className="text-xs text-muted-foreground mt-2 space-y-1 list-disc list-inside">
+              <li>Disable cookies in your browser settings (note: this may affect functionality)</li>
+              <li>Clear your browser&apos;s local storage</li>
+              <li>Opt-out of Google Analytics tracking</li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-foreground mb-2">Children&apos;s Privacy</h2>
+            <p className="text-sm text-muted-foreground leading-relaxed">
+              Our service is not directed to children under the age of 13. We do not knowingly collect
+              personal information from children under 13. If you are a parent or guardian and believe
+              your child has provided us with personal information, please contact us.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-foreground mb-2">Changes to This Privacy Policy</h2>
+            <p className="text-sm text-muted-foreground leading-relaxed">
+              We may update this Privacy Policy from time to time. We will notify you of any changes by
+              posting the new Privacy Policy on this page and updating the &quot;Last updated&quot; date.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-foreground mb-2">Contact Us</h2>
+            <p className="text-sm text-muted-foreground leading-relaxed">
+              If you have any questions about this Privacy Policy, please contact us at:
+            </p>
+            <p className="text-sm text-muted-foreground mt-2">
+              <strong>FX Alert</strong><br />
+              Developed by Nuttapong Buttprom<br />
+              <a href="mailto:contact@fxalert.app" className="text-primary hover:underline">
+                contact@fxalert.app
+              </a>
+            </p>
+          </section>
+        </main>
+
+        {/* Footer */}
+        <footer className="mt-12 pt-6 border-t border-border text-center">
+          <p className="text-xs text-muted-foreground">
+            © 2026 FX Alert. All rights reserved.
+          </p>
+        </footer>
+      </div>
+    </div>
+  );
+}

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,6 +1,6 @@
-import Link from 'next/link';
-import { Home } from 'lucide-react';
 import type { Metadata } from 'next';
+import { LegalLayout } from '@/components/legal-layout';
+import { APP_CONFIG } from '@/lib/constants';
 
 export const metadata: Metadata = {
   title: 'Privacy Policy - FX Alert',
@@ -9,187 +9,160 @@ export const metadata: Metadata = {
 
 export default function PrivacyPolicyPage() {
   return (
-    <div className="min-h-screen bg-background text-foreground flex flex-col items-center p-4 sm:p-6">
-      <div className="w-full max-w-4xl">
-        {/* Back to Home Link */}
-        <Link
-          href="/"
-          className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-primary mb-6 transition-colors"
-        >
-          <Home className="w-4 h-4" />
-          Back to FX Alert
-        </Link>
+    <LegalLayout
+      title="Privacy Policy"
+      description={metadata.description || ''}
+      lastUpdated={APP_CONFIG.LEGAL_LAST_UPDATED}
+    >
+      <section>
+        <h2 className="text-lg font-semibold text-foreground mb-2">Introduction</h2>
+        <p className="text-sm text-muted-foreground leading-relaxed">
+          FX Alert (&quot;we,&quot; &quot;our,&quot; or &quot;us&quot;) is committed to protecting your privacy.
+          This Privacy Policy explains how we collect, use, and disclose information about you when you use our website.
+        </p>
+      </section>
 
-        {/* Header */}
-        <header className="mb-8">
-          <h1 className="text-3xl sm:text-4xl font-bold text-primary mb-2">
-            Privacy Policy
-          </h1>
-          <p className="text-sm text-muted-foreground">
-            Last updated: March 10, 2026
-          </p>
-        </header>
-
-        {/* Content */}
-        <main className="space-y-6">
-          <section>
-            <h2 className="text-lg font-semibold text-foreground mb-2">Introduction</h2>
+      <section>
+        <h2 className="text-lg font-semibold text-foreground mb-2">Information We Collect</h2>
+        <div className="space-y-3">
+          <div>
+            <h3 className="text-sm font-medium text-foreground mb-1">Automatically Collected Information</h3>
             <p className="text-sm text-muted-foreground leading-relaxed">
-              FX Alert (&quot;we,&quot; &quot;our,&quot; or &quot;us&quot;) is committed to protecting your privacy.
-              This Privacy Policy explains how we collect, use, and disclose information about you when you use our website.
-            </p>
-          </section>
-
-          <section>
-            <h2 className="text-lg font-semibold text-foreground mb-2">Information We Collect</h2>
-            <div className="space-y-3">
-              <div>
-                <h3 className="text-sm font-medium text-foreground mb-1">Automatically Collected Information</h3>
-                <p className="text-sm text-muted-foreground leading-relaxed">
-                  We use Google Analytics to collect anonymous usage data, including:
-                </p>
-                <ul className="text-xs text-muted-foreground mt-2 space-y-1 list-disc list-inside">
-                  <li>Browser type and version</li>
-                  <li>Operating system</li>
-                  <li>Referring website</li>
-                  <li>Pages visited and time spent on pages</li>
-                  <li>IP address (anonymized)</li>
-                </ul>
-              </div>
-
-              <div>
-                <h3 className="text-sm font-medium text-foreground mb-1">Cookies and Local Storage</h3>
-                <p className="text-sm text-muted-foreground leading-relaxed">
-                  We use browser cookies and local storage to:
-                </p>
-                <ul className="text-xs text-muted-foreground mt-2 space-y-1 list-disc list-inside">
-                  <li>Remember your currency preferences</li>
-                  <li>Remember your selected analysis period</li>
-                  <li>Remember your alert threshold settings</li>
-                  <li>Analyze site traffic and usage patterns</li>
-                </ul>
-              </div>
-
-              <div>
-                <h3 className="text-sm font-medium text-foreground mb-1">Personal Data</h3>
-                <p className="text-sm text-muted-foreground leading-relaxed">
-                  <strong>We do not collect personal identifiable information (PII)</strong> such as:
-                </p>
-                <ul className="text-xs text-muted-foreground mt-2 space-y-1 list-disc list-inside">
-                  <li>Names</li>
-                  <li>Email addresses</li>
-                  <li>Phone numbers</li>
-                  <li>Physical addresses</li>
-                  <li>Financial account information</li>
-                </ul>
-              </div>
-            </div>
-          </section>
-
-          <section>
-            <h2 className="text-lg font-semibold text-foreground mb-2">How We Use Your Information</h2>
-            <p className="text-sm text-muted-foreground leading-relaxed">
-              We use the collected information to:
+              We use Google Analytics to collect anonymous usage data, including:
             </p>
             <ul className="text-xs text-muted-foreground mt-2 space-y-1 list-disc list-inside">
-              <li>Improve and maintain our service</li>
-              <li>Analyze usage patterns and user behavior</li>
-              <li>Diagnose technical issues</li>
-              <li>Understand which features are most popular</li>
+              <li>Browser type and version</li>
+              <li>Operating system</li>
+              <li>Referring website</li>
+              <li>Pages visited and time spent on pages</li>
+              <li>IP address (anonymized)</li>
             </ul>
-          </section>
+          </div>
 
-          <section>
-            <h2 className="text-lg font-semibold text-foreground mb-2">Third-Party Services</h2>
+          <div>
+            <h3 className="text-sm font-medium text-foreground mb-1">Cookies and Local Storage</h3>
             <p className="text-sm text-muted-foreground leading-relaxed">
-              Our website integrates with the following third-party services:
-            </p>
-            <ul className="text-xs text-muted-foreground mt-2 space-y-2 list-disc list-inside">
-              <li>
-                <strong className="text-foreground">Frankfurter API</strong> — Provides current and historical exchange rate data.
-                They may collect anonymous usage statistics. See their privacy policy at{' '}
-                <a href="https://frankfurter.app" target="_blank" rel="noopener noreferrer" className="text-primary hover:underline">
-                  frankfurter.app
-                </a>.
-              </li>
-              <li>
-                <strong className="text-foreground">Google Analytics</strong> — Analytics service provided by Google LLC.
-                Google may use the collected data to contextualize and personalize the ads of its own advertising network.
-                You can opt-out of Google Analytics by installing the{' '}
-                <a href="https://tools.google.com/dlpage/gaoptout" target="_blank" rel="noopener noreferrer" className="text-primary hover:underline">
-                  Google Analytics Opt-out Browser Add-on
-                </a>.
-              </li>
-              <li>
-                <strong className="text-foreground">Firebase Hosting</strong> — Our website is hosted on Google Firebase.
-                See Google&apos;s privacy policy at{' '}
-                <a href="https://policies.google.com/privacy" target="_blank" rel="noopener noreferrer" className="text-primary hover:underline">
-                  policies.google.com/privacy
-                </a>.
-              </li>
-            </ul>
-          </section>
-
-          <section>
-            <h2 className="text-lg font-semibold text-foreground mb-2">Data Sharing and Disclosure</h2>
-            <p className="text-sm text-muted-foreground leading-relaxed">
-              <strong>We do not sell, trade, or rent your personal identification information to others.</strong>
-              We may share anonymous aggregated data with third parties for the purposes described above.
-            </p>
-          </section>
-
-          <section>
-            <h2 className="text-lg font-semibold text-foreground mb-2">Your Rights and Choices</h2>
-            <p className="text-sm text-muted-foreground leading-relaxed">
-              Since we do not collect personal information, you do not need to request account deletion or data export.
-              However, you can:
+              We use browser cookies and local storage to:
             </p>
             <ul className="text-xs text-muted-foreground mt-2 space-y-1 list-disc list-inside">
-              <li>Disable cookies in your browser settings (note: this may affect functionality)</li>
-              <li>Clear your browser&apos;s local storage</li>
-              <li>Opt-out of Google Analytics tracking</li>
+              <li>Remember your currency preferences</li>
+              <li>Remember your selected analysis period</li>
+              <li>Remember your alert threshold settings</li>
+              <li>Analyze site traffic and usage patterns</li>
             </ul>
-          </section>
+          </div>
 
-          <section>
-            <h2 className="text-lg font-semibold text-foreground mb-2">Children&apos;s Privacy</h2>
+          <div>
+            <h3 className="text-sm font-medium text-foreground mb-1">Personal Data</h3>
             <p className="text-sm text-muted-foreground leading-relaxed">
-              Our service is not directed to children under the age of 13. We do not knowingly collect
-              personal information from children under 13. If you are a parent or guardian and believe
-              your child has provided us with personal information, please contact us.
+              <strong>We do not collect personal identifiable information (PII)</strong> such as:
             </p>
-          </section>
+            <ul className="text-xs text-muted-foreground mt-2 space-y-1 list-disc list-inside">
+              <li>Names</li>
+              <li>Email addresses</li>
+              <li>Phone numbers</li>
+              <li>Physical addresses</li>
+              <li>Financial account information</li>
+            </ul>
+          </div>
+        </div>
+      </section>
 
-          <section>
-            <h2 className="text-lg font-semibold text-foreground mb-2">Changes to This Privacy Policy</h2>
-            <p className="text-sm text-muted-foreground leading-relaxed">
-              We may update this Privacy Policy from time to time. We will notify you of any changes by
-              posting the new Privacy Policy on this page and updating the &quot;Last updated&quot; date.
-            </p>
-          </section>
+      <section>
+        <h2 className="text-lg font-semibold text-foreground mb-2">How We Use Your Information</h2>
+        <p className="text-sm text-muted-foreground leading-relaxed">
+          We use the collected information to:
+        </p>
+        <ul className="text-xs text-muted-foreground mt-2 space-y-1 list-disc list-inside">
+          <li>Improve and maintain our service</li>
+          <li>Analyze usage patterns and user behavior</li>
+          <li>Diagnose technical issues</li>
+          <li>Understand which features are most popular</li>
+        </ul>
+      </section>
 
-          <section>
-            <h2 className="text-lg font-semibold text-foreground mb-2">Contact Us</h2>
-            <p className="text-sm text-muted-foreground leading-relaxed">
-              If you have any questions about this Privacy Policy, please contact us at:
-            </p>
-            <p className="text-sm text-muted-foreground mt-2">
-              <strong>FX Alert</strong><br />
-              Developed by Nuttapong Buttprom<br />
-              <a href="mailto:contact@fxalert.app" className="text-primary hover:underline">
-                contact@fxalert.app
-              </a>
-            </p>
-          </section>
-        </main>
+      <section>
+        <h2 className="text-lg font-semibold text-foreground mb-2">Third-Party Services</h2>
+        <p className="text-sm text-muted-foreground leading-relaxed">
+          Our website integrates with the following third-party services:
+        </p>
+        <ul className="text-xs text-muted-foreground mt-2 space-y-2 list-disc list-inside">
+          <li>
+            <strong className="text-foreground">Frankfurter API</strong> — Provides current and historical exchange rate data.
+            They may collect anonymous usage statistics. See their privacy policy at{' '}
+            <a href="https://frankfurter.app" target="_blank" rel="noopener noreferrer" className="text-primary hover:underline">
+              frankfurter.app
+            </a>.
+          </li>
+          <li>
+            <strong className="text-foreground">Google Analytics</strong> — Analytics service provided by Google LLC.
+            Google may use the collected data to contextualize and personalize the ads of its own advertising network.
+            You can opt-out of Google Analytics by installing the{' '}
+            <a href="https://tools.google.com/dlpage/gaoptout" target="_blank" rel="noopener noreferrer" className="text-primary hover:underline">
+              Google Analytics Opt-out Browser Add-on
+            </a>.
+          </li>
+          <li>
+            <strong className="text-foreground">Firebase Hosting</strong> — Our website is hosted on Google Firebase.
+            See Google&apos;s privacy policy at{' '}
+            <a href="https://policies.google.com/privacy" target="_blank" rel="noopener noreferrer" className="text-primary hover:underline">
+              policies.google.com/privacy
+            </a>.
+          </li>
+        </ul>
+      </section>
 
-        {/* Footer */}
-        <footer className="mt-12 pt-6 border-t border-border text-center">
-          <p className="text-xs text-muted-foreground">
-            © 2026 FX Alert. All rights reserved.
-          </p>
-        </footer>
-      </div>
-    </div>
+      <section>
+        <h2 className="text-lg font-semibold text-foreground mb-2">Data Sharing and Disclosure</h2>
+        <p className="text-sm text-muted-foreground leading-relaxed">
+          <strong>We do not sell, trade, or rent your personal identification information to others.</strong>
+          We may share anonymous aggregated data with third parties for the purposes described above.
+        </p>
+      </section>
+
+      <section>
+        <h2 className="text-lg font-semibold text-foreground mb-2">Your Rights and Choices</h2>
+        <p className="text-sm text-muted-foreground leading-relaxed">
+          Since we do not collect personal information, you do not need to request account deletion or data export.
+          However, you can:
+        </p>
+        <ul className="text-xs text-muted-foreground mt-2 space-y-1 list-disc list-inside">
+          <li>Disable cookies in your browser settings (note: this may affect functionality)</li>
+          <li>Clear your browser&apos;s local storage</li>
+          <li>Opt-out of Google Analytics tracking</li>
+        </ul>
+      </section>
+
+      <section>
+        <h2 className="text-lg font-semibold text-foreground mb-2">Children&apos;s Privacy</h2>
+        <p className="text-sm text-muted-foreground leading-relaxed">
+          Our service is not directed to children under the age of 13. We do not knowingly collect
+          personal information from children under 13. If you are a parent or guardian and believe
+          your child has provided us with personal information, please contact us.
+        </p>
+      </section>
+
+      <section>
+        <h2 className="text-lg font-semibold text-foreground mb-2">Changes to This Privacy Policy</h2>
+        <p className="text-sm text-muted-foreground leading-relaxed">
+          We may update this Privacy Policy from time to time. We will notify you of any changes by
+          posting the new Privacy Policy on this page and updating the &quot;Last updated&quot; date.
+        </p>
+      </section>
+
+      <section>
+        <h2 className="text-lg font-semibold text-foreground mb-2">Contact Us</h2>
+        <p className="text-sm text-muted-foreground leading-relaxed">
+          If you have any questions about this Privacy Policy, please contact us at:
+        </p>
+        <p className="text-sm text-muted-foreground mt-2">
+          <strong>{APP_CONFIG.NAME}</strong><br />
+          Developed by {APP_CONFIG.DEVELOPER}<br />
+          <a href={`mailto:${APP_CONFIG.EMAIL}`} className="text-primary hover:underline">
+            {APP_CONFIG.EMAIL}
+          </a>
+        </p>
+      </section>
+    </LegalLayout>
   );
 }

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,0 +1,210 @@
+import Link from 'next/link';
+import { Home } from 'lucide-react';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Terms of Service - FX Alert',
+  description: 'Terms of Service for FX Alert. Learn about the informational nature of our service and important disclaimers.',
+};
+
+export default function TermsOfServicePage() {
+  return (
+    <div className="min-h-screen bg-background text-foreground flex flex-col items-center p-4 sm:p-6">
+      <div className="w-full max-w-4xl">
+        {/* Back to Home Link */}
+        <Link
+          href="/"
+          className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-primary mb-6 transition-colors"
+        >
+          <Home className="w-4 h-4" />
+          Back to FX Alert
+        </Link>
+
+        {/* Header */}
+        <header className="mb-8">
+          <h1 className="text-3xl sm:text-4xl font-bold text-primary mb-2">
+            Terms of Service
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            Last updated: March 10, 2026
+          </p>
+        </header>
+
+        {/* Content */}
+        <main className="space-y-6">
+          <section>
+            <h2 className="text-lg font-semibold text-foreground mb-2">1. Acceptance of Terms</h2>
+            <p className="text-sm text-muted-foreground leading-relaxed">
+              By accessing and using FX Alert (&quot;the Service&quot;), you accept and agree to be bound by the terms
+              and provisions of this agreement. If you do not agree to abide by these terms, please do not use this service.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-foreground mb-2">2. Description of Service</h2>
+            <p className="text-sm text-muted-foreground leading-relaxed">
+              FX Alert is a free web application that displays foreign exchange rate information, historical analysis,
+              and trend insights. The Service aggregates data from public sources, primarily the Frankfurter API,
+              and presents it for informational purposes only.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-foreground mb-2">3. Informational Nature Only</h2>
+            <p className="text-sm text-muted-foreground leading-relaxed">
+              <strong>IMPORTANT:</strong> The Service is provided for informational and educational purposes only.
+              It does <strong>NOT</strong> constitute:
+            </p>
+            <ul className="text-xs text-muted-foreground mt-2 space-y-1 list-disc list-inside">
+              <li>Financial advice or recommendations</li>
+              <li>Investment advice or recommendations</li>
+              <li>Trading advice or recommendations</li>
+              <li>Tax advice</li>
+              <li>Legal advice</li>
+            </ul>
+            <p className="text-sm text-muted-foreground leading-relaxed mt-2">
+              All content is provided &quot;as is&quot; for general information purposes only.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-foreground mb-2">4. No Professional Relationship</h2>
+            <p className="text-sm text-muted-foreground leading-relaxed">
+              Use of this Service does not create any professional relationship between you and FX Alert, its developer,
+              or any affiliated parties. Nothing on this website should be construed as professional advice.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-foreground mb-2">5. Accuracy of Data</h2>
+            <p className="text-sm text-muted-foreground leading-relaxed">
+              While we strive to provide accurate and up-to-date information, we make no representations or warranties
+              of any kind, express or implied, about the completeness, accuracy, reliability, suitability, or availability
+              of the exchange rate data, historical analysis, or any information on this website.
+            </p>
+            <p className="text-sm text-muted-foreground leading-relaxed mt-2">
+              Exchange rate data is sourced from third-party providers and may be subject to delays, errors, or omissions.
+              Past exchange rates and trends are not indicative of future performance.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-foreground mb-2">6. Disclaimer of Warranties</h2>
+            <p className="text-sm text-muted-foreground leading-relaxed">
+              THE SERVICE IS PROVIDED &quot;AS IS&quot; AND &quot;AS AVAILABLE&quot; WITHOUT WARRANTIES OF ANY KIND,
+              EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO IMPLIED WARRANTIES OF MERCHANTABILITY,
+              FITNESS FOR A PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-foreground mb-2">7. Limitation of Liability</h2>
+            <p className="text-sm text-muted-foreground leading-relaxed">
+              IN NO EVENT SHALL FX ALERT, ITS DEVELOPER, OR ANY AFFILIATED PARTIES BE LIABLE FOR ANY INDIRECT,
+              INCIDENTAL, SPECIAL, CONSEQUENTIAL, OR PUNITIVE DAMAGES, INCLUDING WITHOUT LIMITATION, LOSS OF PROFITS,
+              DATA, USE, GOODWILL, OR OTHER INTANGIBLE LOSSES, RESULTING FROM:
+            </p>
+            <ul className="text-xs text-muted-foreground mt-2 space-y-1 list-disc list-inside">
+              <li>Your access to or use of or inability to access or use the Service</li>
+              <li>Any conduct or content of any third party on the Service</li>
+              <li>Any content obtained from the Service</li>
+              <li>Unauthorized access, use, or alteration of your transmissions or content</li>
+              <li>Financial decisions made based on information from this Service</li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-foreground mb-2">8. Financial Decisions Are Your Responsibility</h2>
+            <p className="text-sm text-muted-foreground leading-relaxed">
+              You acknowledge and agree that you are solely responsible for any financial decisions you make.
+              Always conduct your own research and consult with a qualified financial advisor, tax professional,
+              or legal expert before making any financial, investment, or trading decisions.
+            </p>
+            <p className="text-sm text-muted-foreground leading-relaxed mt-2">
+              <strong>Past performance is not indicative of future results.</strong> All investments carry risk,
+              and you may lose money.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-foreground mb-2">9. Third-Party Links and Services</h2>
+            <p className="text-sm text-muted-foreground leading-relaxed">
+              The Service may contain links to third-party websites or services (including, but not limited to,
+              currency trading platforms). These links are provided for your convenience only.
+            </p>
+            <p className="text-sm text-muted-foreground leading-relaxed mt-2">
+              We do not endorse, guarantee, or assume any responsibility for the content, products, services,
+              or policies of any third-party websites or services. Your interactions with third parties are solely
+              between you and that third party.
+            </p>
+            <p className="text-sm text-muted-foreground leading-relaxed mt-2">
+              Some third-party links may be affiliate links. We may earn a commission if you sign up or make a
+              purchase through these links, at no additional cost to you. This does not influence our recommendations
+              or content.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-foreground mb-2">10. User Conduct</h2>
+            <p className="text-sm text-muted-foreground leading-relaxed">
+              You agree not to:
+            </p>
+            <ul className="text-xs text-muted-foreground mt-2 space-y-1 list-disc list-inside">
+              <li>Use the Service for any illegal purpose</li>
+              <li>Attempt to gain unauthorized access to any portion of the Service</li>
+              <li>Interfere with or disrupt the Service or servers connected to the Service</li>
+              <li>Use automated systems (bots, scrapers) to access the Service excessively</li>
+              <li>Reproduce, duplicate, copy, sell, or exploit any portion of the Service</li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-foreground mb-2">11. Modifications to Service</h2>
+            <p className="text-sm text-muted-foreground leading-relaxed">
+              We reserve the right to modify, suspend, or discontinue the Service at any time with or without notice.
+              We shall not be liable to you or any third party for any modification, suspension, or discontinuation of the Service.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-foreground mb-2">12. Changes to Terms</h2>
+            <p className="text-sm text-muted-foreground leading-relaxed">
+              We may update these Terms of Service from time to time. We will notify you of any changes by
+              posting the new terms on this page and updating the &quot;Last updated&quot; date.
+              Your continued use of the Service after such changes constitutes your acceptance of the new terms.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-foreground mb-2">13. Governing Law</h2>
+            <p className="text-sm text-muted-foreground leading-relaxed">
+              These terms shall be governed by and construed in accordance with the laws of Thailand,
+              without regard to its conflict of law provisions.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-foreground mb-2">14. Contact Information</h2>
+            <p className="text-sm text-muted-foreground leading-relaxed">
+              If you have any questions about these Terms of Service, please contact us at:
+            </p>
+            <p className="text-sm text-muted-foreground mt-2">
+              <strong>FX Alert</strong><br />
+              Developed by Nuttapong Buttprom<br />
+              <a href="mailto:contact@fxalert.app" className="text-primary hover:underline">
+                contact@fxalert.app
+              </a>
+            </p>
+          </section>
+        </main>
+
+        {/* Footer */}
+        <footer className="mt-12 pt-6 border-t border-border text-center">
+          <p className="text-xs text-muted-foreground">
+            © 2026 FX Alert. All rights reserved.
+          </p>
+        </footer>
+      </div>
+    </div>
+  );
+}

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,6 +1,6 @@
-import Link from 'next/link';
-import { Home } from 'lucide-react';
 import type { Metadata } from 'next';
+import { LegalLayout } from '@/components/legal-layout';
+import { APP_CONFIG } from '@/lib/constants';
 
 export const metadata: Metadata = {
   title: 'Terms of Service - FX Alert',
@@ -9,202 +9,175 @@ export const metadata: Metadata = {
 
 export default function TermsOfServicePage() {
   return (
-    <div className="min-h-screen bg-background text-foreground flex flex-col items-center p-4 sm:p-6">
-      <div className="w-full max-w-4xl">
-        {/* Back to Home Link */}
-        <Link
-          href="/"
-          className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-primary mb-6 transition-colors"
-        >
-          <Home className="w-4 h-4" />
-          Back to FX Alert
-        </Link>
+    <LegalLayout
+      title="Terms of Service"
+      description={metadata.description || ''}
+      lastUpdated={APP_CONFIG.LEGAL_LAST_UPDATED}
+    >
+      <section>
+        <h2 className="text-lg font-semibold text-foreground mb-2">1. Acceptance of Terms</h2>
+        <p className="text-sm text-muted-foreground leading-relaxed">
+          By accessing and using FX Alert (&quot;the Service&quot;), you accept and agree to be bound by the terms
+          and provisions of this agreement. If you do not agree to abide by these terms, please do not use this service.
+        </p>
+      </section>
 
-        {/* Header */}
-        <header className="mb-8">
-          <h1 className="text-3xl sm:text-4xl font-bold text-primary mb-2">
-            Terms of Service
-          </h1>
-          <p className="text-sm text-muted-foreground">
-            Last updated: March 10, 2026
-          </p>
-        </header>
+      <section>
+        <h2 className="text-lg font-semibold text-foreground mb-2">2. Description of Service</h2>
+        <p className="text-sm text-muted-foreground leading-relaxed">
+          FX Alert is a free web application that displays foreign exchange rate information, historical analysis,
+          and trend insights. The Service aggregates data from public sources, primarily the Frankfurter API,
+          and presents it for informational purposes only.
+        </p>
+      </section>
 
-        {/* Content */}
-        <main className="space-y-6">
-          <section>
-            <h2 className="text-lg font-semibold text-foreground mb-2">1. Acceptance of Terms</h2>
-            <p className="text-sm text-muted-foreground leading-relaxed">
-              By accessing and using FX Alert (&quot;the Service&quot;), you accept and agree to be bound by the terms
-              and provisions of this agreement. If you do not agree to abide by these terms, please do not use this service.
-            </p>
-          </section>
+      <section>
+        <h2 className="text-lg font-semibold text-foreground mb-2">3. Informational Nature Only</h2>
+        <p className="text-sm text-muted-foreground leading-relaxed">
+          <strong>IMPORTANT:</strong> The Service is provided for informational and educational purposes only.
+          It does <strong>NOT</strong> constitute:
+        </p>
+        <ul className="text-xs text-muted-foreground mt-2 space-y-1 list-disc list-inside">
+          <li>Financial advice or recommendations</li>
+          <li>Investment advice or recommendations</li>
+          <li>Trading advice or recommendations</li>
+          <li>Tax advice</li>
+          <li>Legal advice</li>
+        </ul>
+        <p className="text-sm text-muted-foreground leading-relaxed mt-2">
+          All content is provided &quot;as is&quot; for general information purposes only.
+        </p>
+      </section>
 
-          <section>
-            <h2 className="text-lg font-semibold text-foreground mb-2">2. Description of Service</h2>
-            <p className="text-sm text-muted-foreground leading-relaxed">
-              FX Alert is a free web application that displays foreign exchange rate information, historical analysis,
-              and trend insights. The Service aggregates data from public sources, primarily the Frankfurter API,
-              and presents it for informational purposes only.
-            </p>
-          </section>
+      <section>
+        <h2 className="text-lg font-semibold text-foreground mb-2">4. No Professional Relationship</h2>
+        <p className="text-sm text-muted-foreground leading-relaxed">
+          Use of this Service does not create any professional relationship between you and FX Alert, its developer,
+          or any affiliated parties. Nothing on this website should be construed as professional advice.
+        </p>
+      </section>
 
-          <section>
-            <h2 className="text-lg font-semibold text-foreground mb-2">3. Informational Nature Only</h2>
-            <p className="text-sm text-muted-foreground leading-relaxed">
-              <strong>IMPORTANT:</strong> The Service is provided for informational and educational purposes only.
-              It does <strong>NOT</strong> constitute:
-            </p>
-            <ul className="text-xs text-muted-foreground mt-2 space-y-1 list-disc list-inside">
-              <li>Financial advice or recommendations</li>
-              <li>Investment advice or recommendations</li>
-              <li>Trading advice or recommendations</li>
-              <li>Tax advice</li>
-              <li>Legal advice</li>
-            </ul>
-            <p className="text-sm text-muted-foreground leading-relaxed mt-2">
-              All content is provided &quot;as is&quot; for general information purposes only.
-            </p>
-          </section>
+      <section>
+        <h2 className="text-lg font-semibold text-foreground mb-2">5. Accuracy of Data</h2>
+        <p className="text-sm text-muted-foreground leading-relaxed">
+          While we strive to provide accurate and up-to-date information, we make no representations or warranties
+          of any kind, express or implied, about the completeness, accuracy, reliability, suitability, or availability
+          of the exchange rate data, historical analysis, or any information on this website.
+        </p>
+        <p className="text-sm text-muted-foreground leading-relaxed mt-2">
+          Exchange rate data is sourced from third-party providers and may be subject to delays, errors, or omissions.
+          Past exchange rates and trends are not indicative of future performance.
+        </p>
+      </section>
 
-          <section>
-            <h2 className="text-lg font-semibold text-foreground mb-2">4. No Professional Relationship</h2>
-            <p className="text-sm text-muted-foreground leading-relaxed">
-              Use of this Service does not create any professional relationship between you and FX Alert, its developer,
-              or any affiliated parties. Nothing on this website should be construed as professional advice.
-            </p>
-          </section>
+      <section>
+        <h2 className="text-lg font-semibold text-foreground mb-2">6. Disclaimer of Warranties</h2>
+        <p className="text-sm text-muted-foreground leading-relaxed">
+          THE SERVICE IS PROVIDED &quot;AS IS&quot; AND &quot;AS AVAILABLE&quot; WITHOUT WARRANTIES OF ANY KIND,
+          EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO IMPLIED WARRANTIES OF MERCHANTABILITY,
+          FITNESS FOR A PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT.
+        </p>
+      </section>
 
-          <section>
-            <h2 className="text-lg font-semibold text-foreground mb-2">5. Accuracy of Data</h2>
-            <p className="text-sm text-muted-foreground leading-relaxed">
-              While we strive to provide accurate and up-to-date information, we make no representations or warranties
-              of any kind, express or implied, about the completeness, accuracy, reliability, suitability, or availability
-              of the exchange rate data, historical analysis, or any information on this website.
-            </p>
-            <p className="text-sm text-muted-foreground leading-relaxed mt-2">
-              Exchange rate data is sourced from third-party providers and may be subject to delays, errors, or omissions.
-              Past exchange rates and trends are not indicative of future performance.
-            </p>
-          </section>
+      <section>
+        <h2 className="text-lg font-semibold text-foreground mb-2">7. Limitation of Liability</h2>
+        <p className="text-sm text-muted-foreground leading-relaxed">
+          IN NO EVENT SHALL FX ALERT, ITS DEVELOPER, OR ANY AFFILIATED PARTIES BE LIABLE FOR ANY INDIRECT,
+          INCIDENTAL, SPECIAL, CONSEQUENTIAL, OR PUNITIVE DAMAGES, INCLUDING WITHOUT LIMITATION, LOSS OF PROFITS,
+          DATA, USE, GOODWILL, OR OTHER INTANGIBLE LOSSES, RESULTING FROM:
+        </p>
+        <ul className="text-xs text-muted-foreground mt-2 space-y-1 list-disc list-inside">
+          <li>Your access to or use of or inability to access or use the Service</li>
+          <li>Any conduct or content of any third party on the Service</li>
+          <li>Any content obtained from the Service</li>
+          <li>Unauthorized access, use, or alteration of your transmissions or content</li>
+          <li>Financial decisions made based on information from this Service</li>
+        </ul>
+      </section>
 
-          <section>
-            <h2 className="text-lg font-semibold text-foreground mb-2">6. Disclaimer of Warranties</h2>
-            <p className="text-sm text-muted-foreground leading-relaxed">
-              THE SERVICE IS PROVIDED &quot;AS IS&quot; AND &quot;AS AVAILABLE&quot; WITHOUT WARRANTIES OF ANY KIND,
-              EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO IMPLIED WARRANTIES OF MERCHANTABILITY,
-              FITNESS FOR A PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT.
-            </p>
-          </section>
+      <section>
+        <h2 className="text-lg font-semibold text-foreground mb-2">8. Financial Decisions Are Your Responsibility</h2>
+        <p className="text-sm text-muted-foreground leading-relaxed">
+          You acknowledge and agree that you are solely responsible for any financial decisions you make.
+          Always conduct your own research and consult with a qualified financial advisor, tax professional,
+          or legal expert before making any financial, investment, or trading decisions.
+        </p>
+        <p className="text-sm text-muted-foreground leading-relaxed mt-2">
+          <strong>Past performance is not indicative of future results.</strong> All investments carry risk,
+          and you may lose money.
+        </p>
+      </section>
 
-          <section>
-            <h2 className="text-lg font-semibold text-foreground mb-2">7. Limitation of Liability</h2>
-            <p className="text-sm text-muted-foreground leading-relaxed">
-              IN NO EVENT SHALL FX ALERT, ITS DEVELOPER, OR ANY AFFILIATED PARTIES BE LIABLE FOR ANY INDIRECT,
-              INCIDENTAL, SPECIAL, CONSEQUENTIAL, OR PUNITIVE DAMAGES, INCLUDING WITHOUT LIMITATION, LOSS OF PROFITS,
-              DATA, USE, GOODWILL, OR OTHER INTANGIBLE LOSSES, RESULTING FROM:
-            </p>
-            <ul className="text-xs text-muted-foreground mt-2 space-y-1 list-disc list-inside">
-              <li>Your access to or use of or inability to access or use the Service</li>
-              <li>Any conduct or content of any third party on the Service</li>
-              <li>Any content obtained from the Service</li>
-              <li>Unauthorized access, use, or alteration of your transmissions or content</li>
-              <li>Financial decisions made based on information from this Service</li>
-            </ul>
-          </section>
+      <section>
+        <h2 className="text-lg font-semibold text-foreground mb-2">9. Third-Party Links and Services</h2>
+        <p className="text-sm text-muted-foreground leading-relaxed">
+          The Service may contain links to third-party websites or services (including, but not limited to,
+          currency trading platforms). These links are provided for your convenience only.
+        </p>
+        <p className="text-sm text-muted-foreground leading-relaxed mt-2">
+          We do not endorse, guarantee, or assume any responsibility for the content, products, services,
+          or policies of any third-party websites or services. Your interactions with third parties are solely
+          between you and that third party.
+        </p>
+        <p className="text-sm text-muted-foreground leading-relaxed mt-2">
+          Some third-party links may be affiliate links. We may earn a commission if you sign up or make a
+          purchase through these links, at no additional cost to you. This does not influence our recommendations
+          or content.
+        </p>
+      </section>
 
-          <section>
-            <h2 className="text-lg font-semibold text-foreground mb-2">8. Financial Decisions Are Your Responsibility</h2>
-            <p className="text-sm text-muted-foreground leading-relaxed">
-              You acknowledge and agree that you are solely responsible for any financial decisions you make.
-              Always conduct your own research and consult with a qualified financial advisor, tax professional,
-              or legal expert before making any financial, investment, or trading decisions.
-            </p>
-            <p className="text-sm text-muted-foreground leading-relaxed mt-2">
-              <strong>Past performance is not indicative of future results.</strong> All investments carry risk,
-              and you may lose money.
-            </p>
-          </section>
+      <section>
+        <h2 className="text-lg font-semibold text-foreground mb-2">10. User Conduct</h2>
+        <p className="text-sm text-muted-foreground leading-relaxed">
+          You agree not to:
+        </p>
+        <ul className="text-xs text-muted-foreground mt-2 space-y-1 list-disc list-inside">
+          <li>Use the Service for any illegal purpose</li>
+          <li>Attempt to gain unauthorized access to any portion of the Service</li>
+          <li>Interfere with or disrupt the Service or servers connected to the Service</li>
+          <li>Use automated systems (bots, scrapers) to access the Service excessively</li>
+          <li>Reproduce, duplicate, copy, sell, or exploit any portion of the Service</li>
+        </ul>
+      </section>
 
-          <section>
-            <h2 className="text-lg font-semibold text-foreground mb-2">9. Third-Party Links and Services</h2>
-            <p className="text-sm text-muted-foreground leading-relaxed">
-              The Service may contain links to third-party websites or services (including, but not limited to,
-              currency trading platforms). These links are provided for your convenience only.
-            </p>
-            <p className="text-sm text-muted-foreground leading-relaxed mt-2">
-              We do not endorse, guarantee, or assume any responsibility for the content, products, services,
-              or policies of any third-party websites or services. Your interactions with third parties are solely
-              between you and that third party.
-            </p>
-            <p className="text-sm text-muted-foreground leading-relaxed mt-2">
-              Some third-party links may be affiliate links. We may earn a commission if you sign up or make a
-              purchase through these links, at no additional cost to you. This does not influence our recommendations
-              or content.
-            </p>
-          </section>
+      <section>
+        <h2 className="text-lg font-semibold text-foreground mb-2">11. Modifications to Service</h2>
+        <p className="text-sm text-muted-foreground leading-relaxed">
+          We reserve the right to modify, suspend, or discontinue the Service at any time with or without notice.
+          We shall not be liable to you or any third party for any modification, suspension, or discontinuation of the Service.
+        </p>
+      </section>
 
-          <section>
-            <h2 className="text-lg font-semibold text-foreground mb-2">10. User Conduct</h2>
-            <p className="text-sm text-muted-foreground leading-relaxed">
-              You agree not to:
-            </p>
-            <ul className="text-xs text-muted-foreground mt-2 space-y-1 list-disc list-inside">
-              <li>Use the Service for any illegal purpose</li>
-              <li>Attempt to gain unauthorized access to any portion of the Service</li>
-              <li>Interfere with or disrupt the Service or servers connected to the Service</li>
-              <li>Use automated systems (bots, scrapers) to access the Service excessively</li>
-              <li>Reproduce, duplicate, copy, sell, or exploit any portion of the Service</li>
-            </ul>
-          </section>
+      <section>
+        <h2 className="text-lg font-semibold text-foreground mb-2">12. Changes to Terms</h2>
+        <p className="text-sm text-muted-foreground leading-relaxed">
+          We may update these Terms of Service from time to time. We will notify you of any changes by
+          posting the new terms on this page and updating the &quot;Last updated&quot; date.
+          Your continued use of the Service after such changes constitutes your acceptance of the new terms.
+        </p>
+      </section>
 
-          <section>
-            <h2 className="text-lg font-semibold text-foreground mb-2">11. Modifications to Service</h2>
-            <p className="text-sm text-muted-foreground leading-relaxed">
-              We reserve the right to modify, suspend, or discontinue the Service at any time with or without notice.
-              We shall not be liable to you or any third party for any modification, suspension, or discontinuation of the Service.
-            </p>
-          </section>
+      <section>
+        <h2 className="text-lg font-semibold text-foreground mb-2">13. Governing Law</h2>
+        <p className="text-sm text-muted-foreground leading-relaxed">
+          These terms shall be governed by and construed in accordance with the laws of Thailand,
+          without regard to its conflict of law provisions.
+        </p>
+      </section>
 
-          <section>
-            <h2 className="text-lg font-semibold text-foreground mb-2">12. Changes to Terms</h2>
-            <p className="text-sm text-muted-foreground leading-relaxed">
-              We may update these Terms of Service from time to time. We will notify you of any changes by
-              posting the new terms on this page and updating the &quot;Last updated&quot; date.
-              Your continued use of the Service after such changes constitutes your acceptance of the new terms.
-            </p>
-          </section>
-
-          <section>
-            <h2 className="text-lg font-semibold text-foreground mb-2">13. Governing Law</h2>
-            <p className="text-sm text-muted-foreground leading-relaxed">
-              These terms shall be governed by and construed in accordance with the laws of Thailand,
-              without regard to its conflict of law provisions.
-            </p>
-          </section>
-
-          <section>
-            <h2 className="text-lg font-semibold text-foreground mb-2">14. Contact Information</h2>
-            <p className="text-sm text-muted-foreground leading-relaxed">
-              If you have any questions about these Terms of Service, please contact us at:
-            </p>
-            <p className="text-sm text-muted-foreground mt-2">
-              <strong>FX Alert</strong><br />
-              Developed by Nuttapong Buttprom<br />
-              <a href="mailto:contact@fxalert.app" className="text-primary hover:underline">
-                contact@fxalert.app
-              </a>
-            </p>
-          </section>
-        </main>
-
-        {/* Footer */}
-        <footer className="mt-12 pt-6 border-t border-border text-center">
-          <p className="text-xs text-muted-foreground">
-            © 2026 FX Alert. All rights reserved.
-          </p>
-        </footer>
-      </div>
-    </div>
+      <section>
+        <h2 className="text-lg font-semibold text-foreground mb-2">14. Contact Information</h2>
+        <p className="text-sm text-muted-foreground leading-relaxed">
+          If you have any questions about these Terms of Service, please contact us at:
+        </p>
+        <p className="text-sm text-muted-foreground mt-2">
+          <strong>{APP_CONFIG.NAME}</strong><br />
+          Developed by {APP_CONFIG.DEVELOPER}<br />
+          <a href={`mailto:${APP_CONFIG.EMAIL}`} className="text-primary hover:underline">
+            {APP_CONFIG.EMAIL}
+          </a>
+        </p>
+      </section>
+    </LegalLayout>
   );
 }

--- a/src/components/legal-layout.tsx
+++ b/src/components/legal-layout.tsx
@@ -29,7 +29,7 @@ export function LegalLayout({ title, description, lastUpdated, children }: Legal
           </h1>
           {lastUpdated && (
             <p className="text-sm text-muted-foreground">
-              Last updated: {lastUpdated}
+              Last updated: {new Date(lastUpdated).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}
             </p>
           )}
         </header>
@@ -42,7 +42,7 @@ export function LegalLayout({ title, description, lastUpdated, children }: Legal
         {/* Footer */}
         <footer className="mt-12 pt-6 border-t border-border text-center">
           <p className="text-xs text-muted-foreground">
-            © {new Date().getFullYear()} {title.split(' - ')[0]}. All rights reserved.
+            © {new Date().getFullYear()} FX Alert. All rights reserved.
           </p>
         </footer>
       </div>

--- a/src/components/legal-layout.tsx
+++ b/src/components/legal-layout.tsx
@@ -1,0 +1,51 @@
+import Link from 'next/link';
+import { Home } from 'lucide-react';
+import type { ReactNode } from 'react';
+
+interface LegalLayoutProps {
+  title: string;
+  description: string;
+  lastUpdated?: string;
+  children: ReactNode;
+}
+
+export function LegalLayout({ title, description, lastUpdated, children }: LegalLayoutProps) {
+  return (
+    <div className="min-h-screen bg-background text-foreground flex flex-col items-center p-4 sm:p-6">
+      <div className="w-full max-w-4xl">
+        {/* Back to Home Link */}
+        <Link
+          href="/"
+          className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-primary mb-6 transition-colors"
+        >
+          <Home className="w-4 h-4" />
+          Back to FX Alert
+        </Link>
+
+        {/* Header */}
+        <header className="mb-8">
+          <h1 className="text-3xl sm:text-4xl font-bold text-primary mb-2">
+            {title}
+          </h1>
+          {lastUpdated && (
+            <p className="text-sm text-muted-foreground">
+              Last updated: {lastUpdated}
+            </p>
+          )}
+        </header>
+
+        {/* Content */}
+        <main className="space-y-6">
+          {children}
+        </main>
+
+        {/* Footer */}
+        <footer className="mt-12 pt-6 border-t border-border text-center">
+          <p className="text-xs text-muted-foreground">
+            © {new Date().getFullYear()} {title.split(' - ')[0]}. All rights reserved.
+          </p>
+        </footer>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -6,7 +6,5 @@ export const APP_CONFIG = {
   NAME: 'FX Alert',
   EMAIL: 'kokoabassplayer+fxalert@gmail.com',
   DEVELOPER: 'Nuttapong Buttprom',
-  LEGAL_LAST_UPDATED: 'March 10, 2026',
+  LEGAL_LAST_UPDATED: '2026-03-10',
 } as const;
-
-export const COPYRIGHT_YEAR = new Date().getFullYear();

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,0 +1,12 @@
+/**
+ * Application-wide constants
+ */
+
+export const APP_CONFIG = {
+  NAME: 'FX Alert',
+  EMAIL: 'kokoabassplayer+fxalert@gmail.com',
+  DEVELOPER: 'Nuttapong Buttprom',
+  LEGAL_LAST_UPDATED: 'March 10, 2026',
+} as const;
+
+export const COPYRIGHT_YEAR = new Date().getFullYear();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -19,9 +23,19 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": [
+        "./src/*"
+      ]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    "next-env.d.ts",
+    "build/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## Summary

Adds two required legal pages for Google AdSense approval.

## Changes

- **Privacy Policy** (`/privacy`): Discloses data collection practices (Google Analytics, cookies, local storage), third-party services (Frankfurter API, Firebase Hosting), and user rights
- **Terms of Service** (`/terms`): Comprehensive terms covering informational nature disclaimers, limitation of liability, and affiliate link disclosure
- **Footer links**: Added centered links to both legal pages using Next.js `Link` component

## Technical Details

- Both pages are Server Components with `metadata` exports for SEO
- Zero client-side JavaScript (pure static HTML)
- Styling matches existing app design (Tailwind CSS, shadcn/ui patterns)
- Build output: ~174 B per page

## AdSense Compliance

These pages address key AdSense requirements:
- ✓ Privacy Policy with data collection disclosure
- ✓ Terms of Service with disclaimers
- ✓ Affiliate link transparency
- ✓ Contact information

## Test Plan

- [x] Build succeeds: `npm run build`
- [x] Pages render correctly at `/privacy` and `/terms`
- [x] Footer links navigate properly
- [x] Metadata exports work for SEO

## Screenshots

Preview available in local development at `http://localhost:9002`

🤖 Generated with [Claude Code](https://claude.com/claude-code)