### PR TITLE
feat: add GSC verification meta tag

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -74,6 +74,7 @@ export default function RootLayout({
     <html lang="en" suppressHydrationWarning>
       {/* ②  new <head> with GA4 tag */}
       <head>
+        <meta name="google-site-verification" content="K_hyPn_LQJBVsNa0CkeSssg1NjKXQXsSg-IQ7j231DY" />
         <Script
           src="https://www.googletagmanager.com/gtag/js?id=G-KZMXLJQHEQ"
           strategy="afterInteractive"


### PR DESCRIPTION
## Summary
- Add Google Search Console verification meta tag to layout head

## Context
GSC GA verification method failed because the gtag.js script placement doesn't meet Google's strict `<head>` requirement. Adding the HTML meta tag method instead.

## Test plan
- [x] `npm run build` succeeds
- [ ] Verify ownership passes in Google Search Console

🤖 Generated with [Claude Code](https://claude.com/claude-code)