### PR TITLE
feat: homepage alerts CTA + pricing page redesign

### DIFF
--- a/docs/superpowers/plans/2026-04-17-growth-alerts-cta-pricing.md
+++ b/docs/superpowers/plans/2026-04-17-growth-alerts-cta-pricing.md
@@ -1,0 +1,374 @@
+# Growth: Alerts CTA + Pricing Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Drive traffic from homepage to /alerts via a prominent CTA, and replace the misleading "Coming Soon" pricing page with an honest feature comparison.
+
+**Architecture:** Two standalone UI changes. Homepage gets a teal gradient card section between the rate display and chart. Pricing page gets a full rewrite — removing the 3 disabled cards and replacing with a two-column "Free Today / Coming Later" table. No shared state, no new components, no backend changes.
+
+**Tech Stack:** Next.js 14, React, Tailwind CSS, Lucide React icons, existing shadcn/ui components
+
+---
+
+### Task 1: Create worktree and branch
+
+**Files:**
+- None (git operations only)
+
+- [ ] **Step 1: Create worktree**
+
+```bash
+git worktree add ../fx-alert-growth-27 -b feature/growth-alerts-cta-pricing
+```
+
+- [ ] **Step 2: Verify worktree**
+
+```bash
+cd ../fx-alert-growth-27 && git branch --show-current
+```
+
+Expected: `feature/growth-alerts-cta-pricing`
+
+---
+
+### Task 2: Add alerts CTA card to homepage
+
+**Files:**
+- Modify: `src/app/page.tsx:119-135` (the `<div className="space-y-6">` section)
+
+The CTA card goes between `<CurrentRateDisplay>` and `<HistoryChartDisplay>` inside the `space-y-6` div. It uses the currency pair from page state and the analysis mean from `pairAnalysisData` for the dynamic headline.
+
+- [ ] **Step 1: Add the CTA section to page.tsx**
+
+Insert the following block between `</CurrentRateDisplay>` (line ~128) and `<HistoryChartDisplay` (line ~129) inside the `space-y-6` div:
+
+```tsx
+{/* Alerts CTA Card */}
+<Link
+  href="/alerts"
+  className="block rounded-xl bg-gradient-to-br from-primary to-primary/80 p-6 text-primary-foreground hover:shadow-lg hover:shadow-primary/20 transition-all duration-200"
+>
+  <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
+    <div>
+      <h3 className="text-lg font-semibold mb-1">
+        {pairAnalysisData?.distribution_statistics.mean
+          ? `${selectedFromCurrency}/${selectedToCurrency} averages ${pairAnalysisData.distribution_statistics.mean.toFixed(2)}. Get notified when it hits your target.`
+          : 'Set rate alerts and get notified instantly'}
+      </h3>
+      <p className="text-sm text-primary-foreground/80">
+        Free browser alerts · No signup required · Set up in 30 seconds
+      </p>
+    </div>
+    <div className="flex-shrink-0 px-5 py-2.5 rounded-lg bg-background text-primary font-semibold text-sm hover:bg-background/90 transition-colors">
+      Set Up Free Alerts →
+    </div>
+  </div>
+</Link>
+```
+
+Also add the `Link` import if not already present. The existing imports already include `Link` from usage elsewhere — verify. If not present, add:
+
+```tsx
+import Link from 'next/link';
+```
+
+**Note:** Check whether `Link` is already imported. The current file does not import `Link` — it must be added.
+
+- [ ] **Step 2: Verify in browser**
+
+```bash
+npm run dev
+```
+
+Open http://localhost:9002. Verify:
+- Teal gradient card appears between the rate display and the chart
+- Headline shows the currency pair and average rate (or fallback if no data)
+- CTA button links to `/alerts`
+- Card looks good on mobile (use Chrome DevTools responsive mode)
+
+- [ ] **Step 3: Run type check**
+
+```bash
+npm run typecheck
+```
+
+Expected: No errors
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/app/page.tsx
+git commit -m "feat: add alerts CTA card to homepage
+
+Teal gradient card between rate display and chart promoting /alerts.
+Dynamic headline shows selected currency pair with average rate.
+
+Refs #27"
+```
+
+---
+
+### Task 3: Rewrite pricing page with honest comparison table
+
+**Files:**
+- Modify: `src/app/pricing/page.tsx` (full rewrite of page content)
+
+This task replaces the 3 disabled pricing cards, the "Premium Features" grid, and the old comparison table with a single honest "Free Today vs Coming Later" layout.
+
+- [ ] **Step 1: Rewrite the pricing page**
+
+Replace the entire content of `src/app/pricing/page.tsx` with:
+
+```tsx
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { Check, Clock, Bell, ArrowRight, Mail } from 'lucide-react';
+import { LegalLayout } from '@/components/legal-layout';
+
+export const metadata: Metadata = {
+  title: 'Pricing - FX Alert | Free Exchange Rate Alerts',
+  description: 'RateRefresher is completely free. Set browser alerts for any currency pair, view historical charts, and get AI-powered analysis.',
+};
+
+const freeFeatures = [
+  { feature: 'Live exchange rates', detail: 'Real-time rates from the European Central Bank' },
+  { feature: 'Rate alerts', detail: 'Browser notifications when rates hit your target' },
+  { feature: 'Historical charts', detail: 'Up to 10+ years of rate history with band overlays' },
+  { feature: 'Band analysis', detail: '5-tier classification (Extreme to Rich) based on percentiles' },
+  { feature: 'AI-powered insights', detail: 'Trend analysis and probability distributions' },
+  { feature: 'Multiple currency pairs', detail: 'Track any pair supported by the ECB' },
+];
+
+const comingLater = [
+  'Email rate alerts',
+  'SMS notifications',
+  'Multi-currency watchlists',
+  'Historical data export (CSV/Excel)',
+  'API access',
+  'Priority support',
+  'Advanced analytics',
+];
+
+const faqs = [
+  {
+    q: 'Is everything really free?',
+    a: 'Yes. All features currently available on RateRefresher are free to use with no account required. We plan to introduce premium features in the future.',
+  },
+  {
+    q: 'How do rate alerts work?',
+    a: 'Set a target rate for any currency pair and get a browser notification when it hits. Alerts run in your browser — no account or email needed.',
+  },
+  {
+    q: 'When will premium features launch?',
+    a: 'We\'re working on it. Join our newsletter to be the first to know when premium features go live.',
+  },
+  {
+    q: 'Where does the rate data come from?',
+    a: 'Exchange rates are sourced from the European Central Bank via the Frankfurter API. Rates update once per business day.',
+  },
+];
+
+export default function PricingPage() {
+  return (
+    <LegalLayout
+      title="Pricing"
+      description="RateRefresher is free today. Here's what you get — and what's coming."
+    >
+      {/* Free Today */}
+      <section className="mb-12">
+        <div className="flex items-center gap-2 mb-6">
+          <div className="w-8 h-8 rounded-lg bg-primary/10 flex items-center justify-center">
+            <Check className="w-4 h-4 text-primary" />
+          </div>
+          <h2 className="text-xl font-bold text-foreground">Free Today</h2>
+        </div>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          {freeFeatures.map((item, idx) => (
+            <div
+              key={idx}
+              className="flex items-start gap-3 p-4 rounded-lg border border-primary/20 bg-primary/5"
+            >
+              <Check className="w-4 h-4 text-primary flex-shrink-0 mt-0.5" />
+              <div>
+                <span className="text-sm font-medium text-foreground">{item.feature}</span>
+                <p className="text-xs text-muted-foreground mt-0.5">{item.detail}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+        <div className="mt-6 text-center">
+          <Link
+            href="/alerts"
+            className="inline-flex items-center gap-2 px-6 py-3 text-sm font-medium rounded-lg bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
+          >
+            <Bell className="w-4 h-4" />
+            Start Using Free Alerts
+            <ArrowRight className="w-4 h-4" />
+          </Link>
+        </div>
+      </section>
+
+      {/* Coming Later */}
+      <section className="mb-12">
+        <div className="flex items-center gap-2 mb-6">
+          <div className="w-8 h-8 rounded-lg bg-muted flex items-center justify-center">
+            <Clock className="w-4 h-4 text-muted-foreground" />
+          </div>
+          <h2 className="text-xl font-bold text-foreground">Coming Later</h2>
+        </div>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          {comingLater.map((feature, idx) => (
+            <div
+              key={idx}
+              className="flex items-center gap-3 p-4 rounded-lg border border-border bg-card/30"
+            >
+              <Clock className="w-4 h-4 text-muted-foreground flex-shrink-0" />
+              <span className="text-sm text-muted-foreground">{feature}</span>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* FAQ Section */}
+      <section className="mb-12">
+        <h2 className="text-xl font-bold text-foreground text-center mb-6">
+          Frequently Asked Questions
+        </h2>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          {faqs.map((faq, idx) => (
+            <div key={idx} className="p-4 rounded-lg bg-card/30 border border-border/50">
+              <h3 className="text-sm font-semibold text-foreground mb-2">{faq.q}</h3>
+              <p className="text-xs text-muted-foreground">{faq.a}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* Newsletter CTA */}
+      <section className="bg-gradient-to-br from-primary/5 to-primary/10 rounded-xl p-8 text-center">
+        <h3 className="text-xl font-bold text-foreground mb-3">
+          Be Notified When Premium Features Launch
+        </h3>
+        <p className="text-sm text-muted-foreground mb-6 max-w-md mx-auto">
+          Join our newsletter to be the first to know when premium features go live, plus get early bird pricing.
+        </p>
+        <Link
+          href="/newsletter"
+          className="inline-flex items-center gap-2 px-6 py-3 text-sm font-medium rounded-lg bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
+        >
+          <Mail className="w-4 h-4" />
+          Notify Me at Launch
+        </Link>
+      </section>
+    </LegalLayout>
+  );
+}
+```
+
+- [ ] **Step 2: Verify in browser**
+
+Open http://localhost:9002/pricing. Verify:
+- "Free Today" section with 6 feature cards, each with teal checkmark
+- "Coming Later" section with muted clock icons
+- CTA button "Start Using Free Alerts" links to `/alerts`
+- No "Coming Soon" text anywhere on the page
+- No disabled buttons
+- FAQ section is present with updated questions
+- Newsletter CTA at bottom still works
+- Page looks good on mobile
+
+- [ ] **Step 3: Run type check**
+
+```bash
+npm run typecheck
+```
+
+Expected: No errors
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/app/pricing/page.tsx
+git commit -m "feat: rewrite pricing page with honest feature comparison
+
+Replace 3 disabled 'Coming Soon' cards with 'Free Today / Coming Later'
+layout. Clear value prop above fold, no fake pricing, functional CTA.
+
+Refs #27"
+```
+
+---
+
+### Task 4: Final verification and push
+
+**Files:**
+- None (verification and git operations only)
+
+- [ ] **Step 1: Run full type check**
+
+```bash
+npm run typecheck
+```
+
+Expected: No errors
+
+- [ ] **Step 2: Run linter**
+
+```bash
+npm run lint
+```
+
+Expected: No errors
+
+- [ ] **Step 3: Build**
+
+```bash
+npm run build
+```
+
+Expected: Successful build with no errors
+
+- [ ] **Step 4: Push branch**
+
+```bash
+git push origin feature/growth-alerts-cta-pricing
+```
+
+- [ ] **Step 5: Create PR**
+
+```bash
+gh pr create --title "feat: homepage alerts CTA + pricing page redesign" --body "$(cat <<'EOF'
+## Summary
+- Add teal gradient alerts CTA card to homepage between rate display and chart
+- Rewrite pricing page: replace 3 disabled "Coming Soon" cards with honest "Free Today / Coming Later" comparison
+- Dynamic headline on CTA shows selected currency pair with average rate
+
+## Test plan
+- [ ] Homepage: CTA card visible between rate display and chart
+- [ ] Homepage: headline updates when switching currency pairs
+- [ ] Homepage: CTA links to /alerts
+- [ ] Pricing: "Free Today" section shows 6 working features
+- [ ] Pricing: "Coming Later" section shows 7 planned features
+- [ ] Pricing: no "Coming Soon" text or disabled buttons
+- [ ] Pricing: CTA links to /alerts
+- [ ] Both pages look good on mobile
+
+Closes #27
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+### Task 5: Cleanup worktree
+
+**Files:**
+- None (git operations only)
+
+- [ ] **Step 1: After PR is merged, remove worktree**
+
+```bash
+git worktree remove ../fx-alert-growth-27
+```

--- a/docs/superpowers/specs/2026-04-17-growth-alerts-cta-pricing-design.md
+++ b/docs/superpowers/specs/2026-04-17-growth-alerts-cta-pricing-design.md
@@ -1,0 +1,71 @@
+# Growth: Leverage /alerts and Improve /pricing Conversion
+
+**Date:** 2026-04-17
+**Issue:** #27
+**Status:** Approved
+**Approach:** Focused Two-Page Update
+
+## Problem
+
+GA4 data shows `/alerts` is the highest-engagement page (4m 55s avg, 28% bounce) but gets minimal traffic (42 views/90 days). `/pricing` gets clicks (14 views) but 14s avg time — people arrive, see "Coming Soon" on everything, and bounce immediately.
+
+## Scope
+
+Two files modified, no new components, no backend changes:
+- `src/app/page.tsx` — Add alerts CTA card
+- `src/app/pricing/page.tsx` — Replace 3-card layout with honest comparison table
+
+## Design
+
+### 1. Homepage Alerts CTA Card
+
+**Placement:** Between the rate display (`CurrentRateDisplay`) and the historical chart section in `src/app/page.tsx`.
+
+**Content:**
+- Dynamic headline tied to the current rate and selected currency pair: *"USD/THB is at 33.42 right now. Get notified when it hits your target."*
+- Fallback when rate data hasn't loaded: *"Set rate alerts and get notified instantly"*
+- Subtext: *"Free browser alerts · No signup required · Set up in 30 seconds"*
+- CTA button: *"Set Up Free Alerts"* → links to `/alerts`
+
+**Visual:** Teal gradient card matching the brand accent color. Inline `<section>` with Tailwind classes — no new component file.
+
+**Behavior:**
+- Headline updates dynamically based on selected currency pair (reads from existing page state)
+- Always visible, no dismissal logic
+- Currency pair in headline matches user selection (not hardcoded to USD/THB)
+
+### 2. Pricing Page Redesign
+
+**Replace the 3 disabled pricing cards with an honest comparison table.**
+
+**Structure:**
+1. **Hero** — Updated copy: *"RateRefresher is free today. Here's what you get — and what's coming."*
+2. **Comparison table** — Two columns:
+   - **"Free Today"** (left, teal-accented): Live rates, historical charts, band analysis, AI insights, browser rate alerts, currency pair selection
+   - **"Coming Later"** (right, muted): Email alerts, SMS notifications, multi-currency watchlists, API access, priority support, advanced analytics
+3. **CTA** — Single prominent button: *"Start Using Free Alerts →"* → links to `/alerts`
+4. **Newsletter banner** — Keep existing newsletter signup at bottom
+5. **FAQ** — Keep existing FAQ section, update any "Coming Soon" references
+
+**Layout:** Clean table with feature rows. Checkmarks for free features, clock icons for coming-later features. No fake pricing numbers. No disabled buttons.
+
+## Out of Scope
+
+- Payment integration or subscription logic
+- Email capture or push notification infrastructure
+- Changes to the `/alerts` page itself
+- Social sharing features
+- Backend changes
+
+## Success Metrics
+
+- **Primary:** `/alerts` page views increase from baseline (42 views/90 days)
+- **Secondary:** `/pricing` avg time increases from 14 seconds
+- **Tertiary:** Homepage CTA click-through rate (trackable via GA4 event or utm parameter)
+
+## Testing
+
+- Manual: CTA appears on homepage, updates with currency pair, links to `/alerts`
+- Manual: Pricing page shows comparison table, no "Coming Soon" text, CTA links to `/alerts`
+- Visual: Check both pages on mobile and desktop
+- Type check: `npm run typecheck` passes

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -132,7 +132,7 @@ const UsdThbMonitorPage: FC = () => {
     <>
       {/* Data source: always mounted to fetch rate/currency/band data.
           Visible on desktop, hidden on mobile via CSS. */}
-      <div className="hidden md:block">
+      <div className="hidden md:block w-full max-w-4xl mx-auto px-4 sm:px-6 pt-8">
         <CurrentRateDisplay
           alertPrefs={alertPrefs}
           onAlertPrefsChange={setAlertPrefs}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,7 @@
 
 import type { FC } from 'react';
 import { useState, useEffect, useCallback } from 'react';
+import Link from 'next/link';
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { TrendingUp, ExternalLink, Award } from 'lucide-react';
@@ -144,6 +145,27 @@ const UsdThbMonitorPage: FC = () => {
           onBandChange={setMobileCurrentBand}
           onCurrenciesChange={setMobileCurrencies}
         />
+        {/* Alerts CTA Card (desktop only) */}
+        <Link
+          href="/alerts"
+          className="block rounded-xl bg-gradient-to-br from-primary to-primary/80 p-6 text-primary-foreground hover:shadow-lg hover:shadow-primary/20 transition-all duration-200"
+        >
+          <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
+            <div>
+              <h3 className="text-lg font-semibold mb-1">
+                {pairAnalysisData?.distribution_statistics.mean
+                  ? `${selectedFromCurrency}/${selectedToCurrency} averages ${pairAnalysisData.distribution_statistics.mean.toFixed(2)}. Get notified when it hits your target.`
+                  : 'Set rate alerts and get notified instantly'}
+              </h3>
+              <p className="text-sm text-primary-foreground/80">
+                Free browser alerts · No signup required · Set up in 30 seconds
+              </p>
+            </div>
+            <div className="flex-shrink-0 px-5 py-2.5 rounded-lg bg-background text-primary font-semibold text-sm hover:bg-background/90 transition-colors">
+              Set Up Free Alerts →
+            </div>
+          </div>
+        </Link>
       </div>
 
       {/* ========== MOBILE LAYOUT ========== */}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -145,7 +145,6 @@ const UsdThbMonitorPage: FC = () => {
           onBandChange={setMobileCurrentBand}
           onCurrenciesChange={setMobileCurrencies}
         />
-        {/* Alerts CTA Card (desktop only) */}
         <Link
           href="/alerts"
           className="block rounded-xl bg-gradient-to-br from-primary to-primary/80 p-6 text-primary-foreground hover:shadow-lg hover:shadow-primary/20 transition-all duration-200"

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -1,220 +1,107 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
-import { Home, Check, Zap, Mail, Bell, BarChart3, Clock, Users } from 'lucide-react';
+import { Check, Clock, Bell, ArrowRight, Mail } from 'lucide-react';
 import { LegalLayout } from '@/components/legal-layout';
-import { APP_CONFIG } from '@/lib/constants';
 
 export const metadata: Metadata = {
-  title: 'Pricing - FX Alert | Premium Exchange Rate Alerts',
-  description: 'Get daily email and SMS alerts when exchange rates hit your target levels. Rates update once per day from the European Central Bank.',
+  title: 'Pricing - FX Alert | Free Exchange Rate Alerts',
+  description: 'RateRefresher is completely free. Set browser alerts for any currency pair, view historical charts, and get AI-powered analysis.',
 };
 
-const plans = [
-  {
-    name: 'Free',
-    price: '0',
-    period: 'forever',
-    description: 'Perfect for casual rate monitoring',
-    icon: Bell,
-    features: [
-      'Browser notifications only',
-      'Daily rate display with manual refresh',
-      'Historical charts (up to 10 years)',
-      'Rate band classification',
-      'AI-powered analysis',
-      '5 currency pairs saved',
-    ],
-    cta: 'Current Plan',
-    highlighted: false,
-    disabled: true,
-  },
-  {
-    name: 'Premium',
-    price: '199',
-    period: 'THB/month',
-    description: 'For regular senders and expats',
-    icon: Mail,
-    features: [
-      'Everything in Free',
-      'Email rate alerts',
-      'Custom rate thresholds',
-      'Daily/Weekly rate summaries',
-      'Unlimited currency pairs',
-      'Priority support',
-      'No ads',
-    ],
-    cta: 'Coming Soon',
-    highlighted: true,
-    disabled: true,
-    badge: 'Popular',
-  },
-  {
-    name: 'Pro',
-    price: '499',
-    period: 'THB/month',
-    description: 'For businesses and active traders',
-    icon: Zap,
-    features: [
-      'Everything in Premium',
-      'SMS rate alerts',
-      'Daily push notifications',
-      'Advanced trend indicators',
-      'Historical data export (CSV/Excel)',
-      'API access (1,000 calls/month)',
-      'Custom reports',
-      'Dedicated support',
-    ],
-    cta: 'Coming Soon',
-    highlighted: false,
-    disabled: true,
-    badge: 'Best Value',
-  },
+const freeFeatures = [
+  { feature: 'Live exchange rates', detail: 'Real-time rates from the European Central Bank' },
+  { feature: 'Rate alerts', detail: 'Browser notifications when rates hit your target' },
+  { feature: 'Historical charts', detail: 'Up to 10+ years of rate history with band overlays' },
+  { feature: 'Band analysis', detail: '5-tier classification (Extreme to Rich) based on percentiles' },
+  { feature: 'AI-powered insights', detail: 'Trend analysis and probability distributions' },
+  { feature: 'Multiple currency pairs', detail: 'Track any pair supported by the ECB' },
 ];
 
-const features = [
-  {
-    icon: Bell,
-    title: 'Smart Rate Alerts',
-    description: 'Get notified when rates cross your target thresholds. Set upper and lower limits for any currency pair.',
-  },
-  {
-    icon: Mail,
-    title: 'Email Notifications',
-    description: 'Receive daily or weekly summaries directly in your inbox. Never miss an opportunity to exchange at favorable rates.',
-  },
-  {
-    icon: Zap,
-    title: 'SMS Alerts',
-    description: 'Daily SMS notifications when rates hit your target. Rates update once per day.',
-  },
-  {
-    icon: BarChart3,
-    title: 'Historical Data Export',
-    description: 'Export up to 10 years of historical rate data as CSV or Excel for your own analysis and reporting.',
-  },
-  {
-    icon: Clock,
-    title: 'Rate History Trends',
-    description: 'Access detailed historical trends with moving averages, volatility metrics, and seasonal patterns.',
-  },
-  {
-    icon: Users,
-    title: 'Priority Support',
-    description: 'Get faster response times and dedicated support for your questions and feature requests.',
-  },
+const comingLater = [
+  'Email rate alerts',
+  'SMS notifications',
+  'Multi-currency watchlists',
+  'Historical data export (CSV/Excel)',
+  'API access',
+  'Priority support',
+  'Advanced analytics',
 ];
 
 const faqs = [
   {
-    q: 'When will premium features be available?',
-    a: 'We\'re currently finalizing the premium features. Join our newsletter to be notified when we launch.',
+    q: 'Is everything really free?',
+    a: 'Yes. All features currently available on RateRefresher are free to use with no account required. We plan to introduce premium features in the future.',
   },
   {
-    q: 'Can I cancel my subscription anytime?',
-    a: 'Yes! You can cancel your subscription at any time. Your access continues until the end of your billing period.',
+    q: 'How do rate alerts work?',
+    a: 'Set a target rate for any currency pair and get a browser notification when it hits. Alerts run in your browser — no account or email needed.',
   },
   {
-    q: 'What payment methods do you accept?',
-    a: 'We accept credit/debit cards, PayPal, and Thai bank transfers via Stripe secure payment processing.',
+    q: 'When will premium features launch?',
+    a: 'We\'re working on it. Join our newsletter to be the first to know when premium features go live.',
   },
   {
-    q: 'Is there a free trial?',
-    a: 'Yes! When we launch, Premium and Pro plans will include a 7-day free trial with full feature access.',
+    q: 'Where does the rate data come from?',
+    a: 'Exchange rates are sourced from the European Central Bank via the Frankfurter API. Rates update once per business day.',
   },
 ];
 
 export default function PricingPage() {
   return (
     <LegalLayout
-      title="Pricing Plans"
-      description={metadata.description || ''}
+      title="Pricing"
+      description="RateRefresher is free today. Here's what you get — and what's coming."
     >
-      {/* Hero Section */}
-      <section className="text-center mb-12">
-        <h2 className="text-2xl sm:text-3xl font-bold text-foreground mb-3">
-          Choose Your Plan
-        </h2>
-        <p className="text-sm text-muted-foreground max-w-xl mx-auto">
-          Start free and upgrade when you need advanced features. No hidden fees, cancel anytime.
-        </p>
-      </section>
-
-      {/* Pricing Cards */}
-      <section className="mb-16">
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-          {plans.map((plan, idx) => (
+      {/* Free Today */}
+      <section className="mb-12">
+        <div className="flex items-center gap-2 mb-6">
+          <div className="w-8 h-8 rounded-lg bg-primary/10 flex items-center justify-center">
+            <Check className="w-4 h-4 text-primary" />
+          </div>
+          <h2 className="text-xl font-bold text-foreground">Free Today</h2>
+        </div>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          {freeFeatures.map((item, idx) => (
             <div
               key={idx}
-              className={`relative rounded-xl p-6 border ${
-                plan.highlighted
-                  ? 'border-primary bg-gradient-to-b from-primary/5 to-background ring-2 ring-primary/20'
-                  : 'border-border bg-card/50'
-              }`}
+              className="flex items-start gap-3 p-4 rounded-lg border border-primary/20 bg-primary/5"
             >
-              {plan.badge && (
-                <div className="absolute -top-3 left-1/2 -translate-x-1/2 px-3 py-1 text-xs font-semibold rounded-full bg-primary text-primary-foreground">
-                  {plan.badge}
-                </div>
-              )}
-
-              <div className="flex items-center gap-3 mb-4">
-                <div className={`w-12 h-12 rounded-lg flex items-center justify-center ${
-                  plan.highlighted ? 'bg-primary/20' : 'bg-muted'
-                }`}>
-                  <plan.icon className={`w-6 h-6 ${plan.highlighted ? 'text-primary' : 'text-muted-foreground'}`} />
-                </div>
-                <div>
-                  <h3 className="text-lg font-bold text-foreground">{plan.name}</h3>
-                  <p className="text-xs text-muted-foreground">{plan.description}</p>
-                </div>
+              <Check className="w-4 h-4 text-primary flex-shrink-0 mt-0.5" />
+              <div>
+                <span className="text-sm font-medium text-foreground">{item.feature}</span>
+                <p className="text-xs text-muted-foreground mt-0.5">{item.detail}</p>
               </div>
-
-              <div className="mb-6">
-                <span className="text-3xl font-bold text-foreground">{plan.price}</span>
-                {plan.price !== '0' && <span className="text-sm text-muted-foreground">/{plan.period}</span>}
-              </div>
-
-              <ul className="space-y-2 mb-6">
-                {plan.features.map((feature, featureIdx) => (
-                  <li key={featureIdx} className="flex items-start gap-2 text-xs">
-                    <Check className="w-4 h-4 text-green-600 flex-shrink-0 mt-0.5" />
-                    <span className="text-muted-foreground">{feature}</span>
-                  </li>
-                ))}
-              </ul>
-
-              <button
-                disabled={plan.disabled}
-                className={`w-full py-2.5 text-sm font-medium rounded-lg transition-colors ${
-                  plan.disabled
-                    ? 'bg-muted text-muted-foreground cursor-not-allowed'
-                    : plan.highlighted
-                    ? 'bg-primary text-primary-foreground hover:bg-primary/90'
-                    : 'border border-border text-foreground hover:bg-muted'
-                }`}
-              >
-                {plan.cta}
-              </button>
             </div>
           ))}
         </div>
+        <div className="mt-6 text-center">
+          <Link
+            href="/alerts"
+            className="inline-flex items-center gap-2 px-6 py-3 text-sm font-medium rounded-lg bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
+          >
+            <Bell className="w-4 h-4" />
+            Start Using Free Alerts
+            <ArrowRight className="w-4 h-4" />
+          </Link>
+        </div>
       </section>
 
-      {/* Features Section */}
-      <section className="mb-16">
-        <h2 className="text-xl font-bold text-foreground text-center mb-8">
-          Premium Features
-        </h2>
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-          {features.map((feature, idx) => (
-            <div key={idx} className="flex gap-4 p-4 rounded-lg bg-card/30 border border-border/50">
-              <div className="flex-shrink-0 w-12 h-12 rounded-lg bg-primary/10 flex items-center justify-center">
-                <feature.icon className="w-6 h-6 text-primary" />
-              </div>
-              <div>
-                <h3 className="text-sm font-semibold text-foreground mb-1">{feature.title}</h3>
-                <p className="text-xs text-muted-foreground">{feature.description}</p>
-              </div>
+      {/* Coming Later */}
+      <section className="mb-12">
+        <div className="flex items-center gap-2 mb-6">
+          <div className="w-8 h-8 rounded-lg bg-muted flex items-center justify-center">
+            <Clock className="w-4 h-4 text-muted-foreground" />
+          </div>
+          <h2 className="text-xl font-bold text-foreground">Coming Later</h2>
+        </div>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          {comingLater.map((feature, idx) => (
+            <div
+              key={idx}
+              className="flex items-center gap-3 p-4 rounded-lg border border-border bg-card/30"
+            >
+              <Clock className="w-4 h-4 text-muted-foreground flex-shrink-0" />
+              <span className="text-sm text-muted-foreground">{feature}</span>
             </div>
           ))}
         </div>
@@ -235,10 +122,10 @@ export default function PricingPage() {
         </div>
       </section>
 
-      {/* CTA Section */}
+      {/* Newsletter CTA */}
       <section className="bg-gradient-to-br from-primary/5 to-primary/10 rounded-xl p-8 text-center">
         <h3 className="text-xl font-bold text-foreground mb-3">
-          Be Notified When We Launch Premium Features
+          Be Notified When Premium Features Launch
         </h3>
         <p className="text-sm text-muted-foreground mb-6 max-w-md mx-auto">
           Join our newsletter to be the first to know when premium features go live, plus get early bird pricing.
@@ -250,75 +137,6 @@ export default function PricingPage() {
           <Mail className="w-4 h-4" />
           Notify Me at Launch
         </Link>
-      </section>
-
-      {/* Comparison Table */}
-      <section className="mt-12">
-        <h2 className="text-lg font-semibold text-foreground mb-4 text-center">
-          Feature Comparison
-        </h2>
-        <div className="overflow-x-auto">
-          <table className="w-full text-xs border-collapse">
-            <thead>
-              <tr className="bg-muted/50">
-                <th className="border border-border px-4 py-3 text-left font-semibold">Feature</th>
-                <th className="border border-border px-4 py-3 text-center font-semibold">Free</th>
-                <th className="border border-border px-4 py-3 text-center font-semibold bg-primary/10">Premium</th>
-                <th className="border border-border px-4 py-3 text-center font-semibold">Pro</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td className="border border-border px-4 py-2">Browser Notifications</td>
-                <td className="border border-border px-4 py-2 text-center">✓</td>
-                <td className="border border-border px-4 py-2 text-center bg-primary/5">✓</td>
-                <td className="border border-border px-4 py-2 text-center">✓</td>
-              </tr>
-              <tr className="bg-muted/20">
-                <td className="border border-border px-4 py-2">Email Alerts</td>
-                <td className="border border-border px-4 py-2 text-center">—</td>
-                <td className="border border-border px-4 py-2 text-center bg-primary/5">✓</td>
-                <td className="border border-border px-4 py-2 text-center">✓</td>
-              </tr>
-              <tr>
-                <td className="border border-border px-4 py-2">SMS Alerts</td>
-                <td className="border border-border px-4 py-2 text-center">—</td>
-                <td className="border border-border px-4 py-2 text-center bg-primary/5">—</td>
-                <td className="border border-border px-4 py-2 text-center">✓</td>
-              </tr>
-              <tr className="bg-muted/20">
-                <td className="border border-border px-4 py-2">Custom Rate Thresholds</td>
-                <td className="border border-border px-4 py-2 text-center">—</td>
-                <td className="border border-border px-4 py-2 text-center bg-primary/5">✓</td>
-                <td className="border border-border px-4 py-2 text-center">✓</td>
-              </tr>
-              <tr>
-                <td className="border border-border px-4 py-2">Historical Data Export</td>
-                <td className="border border-border px-4 py-2 text-center">—</td>
-                <td className="border border-border px-4 py-2 text-center bg-primary/5">—</td>
-                <td className="border border-border px-4 py-2 text-center">✓</td>
-              </tr>
-              <tr className="bg-muted/20">
-                <td className="border border-border px-4 py-2">API Access</td>
-                <td className="border border-border px-4 py-2 text-center">—</td>
-                <td className="border border-border px-4 py-2 text-center bg-primary/5">—</td>
-                <td className="border border-border px-4 py-2 text-center">1,000/mo</td>
-              </tr>
-              <tr>
-                <td className="border border-border px-4 py-2">Currency Pairs</td>
-                <td className="border border-border px-4 py-2 text-center">5</td>
-                <td className="border border-border px-4 py-2 text-center bg-primary/5">Unlimited</td>
-                <td className="border border-border px-4 py-2 text-center">Unlimited</td>
-              </tr>
-              <tr className="bg-muted/20">
-                <td className="border border-border px-4 py-2">Price</td>
-                <td className="border border-border px-4 py-2 text-center font-semibold">Free</td>
-                <td className="border border-border px-4 py-2 text-center font-semibold bg-primary/5">199 THB/mo</td>
-                <td className="border border-border px-4 py-2 text-center font-semibold">499 THB/mo</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
       </section>
     </LegalLayout>
   );

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -9,7 +9,7 @@ export const metadata: Metadata = {
 };
 
 const freeFeatures = [
-  { feature: 'Live exchange rates', detail: 'Real-time rates from the European Central Bank' },
+  { feature: 'Exchange rates', detail: 'Rates from the European Central Bank, updated daily' },
   { feature: 'Rate alerts', detail: 'Browser notifications when rates hit your target' },
   { feature: 'Historical charts', detail: 'Up to 10+ years of rate history with band overlays' },
   { feature: 'Band analysis', detail: '5-tier classification (Extreme to Rich) based on percentiles' },


### PR DESCRIPTION
## Summary
- Add teal gradient alerts CTA card to homepage between rate display and chart
- Rewrite pricing page: replace 3 disabled "Coming Soon" cards with honest "Free Today / Coming Later" comparison
- Dynamic headline on CTA shows selected currency pair with average rate

## Test plan
- [ ] Homepage: CTA card visible between rate display and chart
- [ ] Homepage: headline updates when switching currency pairs
- [ ] Homepage: CTA links to /alerts
- [ ] Pricing: "Free Today" section shows 6 working features
- [ ] Pricing: "Coming Later" section shows 7 planned features
- [ ] Pricing: no "Coming Soon" text or disabled buttons
- [ ] Pricing: CTA links to /alerts
- [ ] Both pages look good on mobile

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)