### PR TITLE
feat: add contact page with GitHub Issues feedback links

### DIFF
--- a/docs/superpowers/plans/2026-04-18-contact-page.md
+++ b/docs/superpowers/plans/2026-04-18-contact-page.md
@@ -1,0 +1,190 @@
+# Contact Page Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `/contact` page with email and GitHub Issues links for AdSense compliance and user feedback.
+
+**Architecture:** Single new page using the existing `LegalLayout` component, plus a footer nav link update. No new components, no backend, no API calls.
+
+**Tech Stack:** Next.js App Router, React, Tailwind CSS, existing `LegalLayout` and `APP_CONFIG`.
+
+---
+
+### Task 1: Create the Contact Page
+
+**Files:**
+- Create: `src/app/contact/page.tsx`
+
+- [ ] **Step 1: Create the contact page file**
+
+```tsx
+import type { Metadata } from 'next';
+import { LegalLayout } from '@/components/legal-layout';
+import { APP_CONFIG } from '@/lib/constants';
+
+export const metadata: Metadata = {
+  title: 'Contact Us - FX Alert',
+  description: 'Get in touch with FX Alert. Report bugs, request features, or send us feedback via email or GitHub.',
+};
+
+const GITHUB_REPO = 'Kokoabassplayer/fx-alert';
+
+export default function ContactPage() {
+  return (
+    <LegalLayout
+      title="Contact Us"
+      description={metadata.description || ''}
+    >
+      <section>
+        <h2 className="text-lg font-semibold text-foreground mb-2">Get in Touch</h2>
+        <p className="text-sm text-muted-foreground leading-relaxed">
+          Have a question, found a bug, or want to request a feature? Here&apos;s how to reach us.
+          We use GitHub Issues to track feedback so nothing gets lost.
+        </p>
+      </section>
+
+      <section>
+        <h2 className="text-lg font-semibold text-foreground mb-2">Email</h2>
+        <p className="text-sm text-muted-foreground leading-relaxed">
+          For general inquiries, reach us at{' '}
+          <a href={`mailto:${APP_CONFIG.EMAIL}`} className="text-primary hover:underline">
+            {APP_CONFIG.EMAIL}
+          </a>.
+        </p>
+      </section>
+
+      <section>
+        <h2 className="text-lg font-semibold text-foreground mb-2">Report a Bug</h2>
+        <p className="text-sm text-muted-foreground leading-relaxed">
+          Found something broken? Open a bug report on GitHub and we&apos;ll look into it.
+        </p>
+        <a
+          href={`https://github.com/${GITHUB_REPO}/issues/new?labels=bug&template=bug_report.md&title=%5BBUG%5D+`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-block mt-2 text-sm text-primary hover:underline"
+        >
+          Open a Bug Report →
+        </a>
+      </section>
+
+      <section>
+        <h2 className="text-lg font-semibold text-foreground mb-2">Request a Feature</h2>
+        <p className="text-sm text-muted-foreground leading-relaxed">
+          Have an idea that would make FX Alert better? We&apos;d love to hear it.
+        </p>
+        <a
+          href={`https://github.com/${GITHUB_REPO}/issues/new?labels=enhancement&template=feature_request.md&title=%5BFEATURE%5D+`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-block mt-2 text-sm text-primary hover:underline"
+        >
+          Request a Feature →
+        </a>
+      </section>
+
+      <section>
+        <h2 className="text-lg font-semibold text-foreground mb-2">General Feedback</h2>
+        <p className="text-sm text-muted-foreground leading-relaxed">
+          Anything else on your mind? Open a general issue on GitHub.
+        </p>
+        <a
+          href={`https://github.com/${GITHUB_REPO}/issues/new`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-block mt-2 text-sm text-primary hover:underline"
+        >
+          Open an Issue →
+        </a>
+      </section>
+    </LegalLayout>
+  );
+}
+```
+
+- [ ] **Step 2: Run typecheck to verify**
+
+Run: `npx tsc --noEmit`
+Expected: No errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app/contact/page.tsx
+git commit -m "feat: add /contact page with email and GitHub Issues links"
+```
+
+---
+
+### Task 2: Add Contact Link to Footer
+
+**Files:**
+- Modify: `src/components/site-footer.tsx`
+
+- [ ] **Step 1: Add Contact link between Privacy and Terms**
+
+In `src/components/site-footer.tsx`, add a "Contact" link after the "Privacy" link (around line 49-53). The existing pattern is:
+
+```tsx
+<Link href="/privacy" className="text-muted-foreground hover:text-primary transition-colors">
+  Privacy
+</Link>
+<span className="text-muted-foreground">•</span>
+<Link href="/terms" className="text-muted-foreground hover:text-primary transition-colors">
+  Terms
+</Link>
+```
+
+Insert Contact between Privacy and Terms:
+
+```tsx
+<Link href="/privacy" className="text-muted-foreground hover:text-primary transition-colors">
+  Privacy
+</Link>
+<span className="text-muted-foreground">•</span>
+<Link href="/contact" className="text-muted-foreground hover:text-primary transition-colors">
+  Contact
+</Link>
+<span className="text-muted-foreground">•</span>
+<Link href="/terms" className="text-muted-foreground hover:text-primary transition-colors">
+  Terms
+</Link>
+```
+
+- [ ] **Step 2: Run typecheck to verify**
+
+Run: `npx tsc --noEmit`
+Expected: No errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/site-footer.tsx
+git commit -m "feat: add Contact link to footer navigation"
+```
+
+---
+
+### Task 3: Verify and Final Commit
+
+- [ ] **Step 1: Run full typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: No errors
+
+- [ ] **Step 2: Start dev server and visually verify**
+
+Run: `npm run dev`
+Check: `http://localhost:9002/contact`
+- Page loads with all 5 sections
+- Email link opens mail client
+- All GitHub links open correct URLs with correct labels
+- Footer Contact link navigates to `/contact`
+- Visual style matches privacy/terms pages
+- Page looks good on mobile viewport
+
+- [ ] **Step 3: Push branch**
+
+```bash
+git push origin worktree-feature+contact-page
+```

--- a/docs/superpowers/specs/2026-04-18-contact-page-design.md
+++ b/docs/superpowers/specs/2026-04-18-contact-page-design.md
@@ -1,0 +1,63 @@
+# Contact Page
+
+**Date:** 2026-04-18
+**Status:** Approved
+**Approach:** Simple LegalLayout page with email + GitHub Issues links
+
+## Problem
+
+FX Alert has no `/contact` page. This is needed for:
+1. **AdSense eligibility** — Google requires a contact/about/privacy page
+2. **User feedback** — users need a way to report bugs, request features, and send general feedback
+3. **Legal compliance** — privacy policy and terms pages reference contact info but there's no dedicated page
+
+## Scope
+
+Two files:
+- `src/app/contact/page.tsx` — new contact page
+- `src/components/site-footer.tsx` — add Contact link to footer nav
+
+No backend, no new components, no API calls.
+
+## Design
+
+### Contact Page (`src/app/contact/page.tsx`)
+
+Uses existing `LegalLayout` component (consistent with privacy/terms/about pages).
+
+**Sections:**
+
+1. **Get in Touch** — Brief intro paragraph explaining the contact options
+
+2. **Email** — Shows `APP_CONFIG.EMAIL` with `mailto:` link for general inquiries
+
+3. **Report a Bug** — Link to GitHub Issues with `labels=bug&template=bug_report.md` pre-filled. Opens: `https://github.com/Kokoabassplayer/fx-alert/issues/new?labels=bug&template=bug_report.md&title=%5BBUG%5D+`
+
+4. **Request a Feature** — Link to GitHub Issues with `labels=enhancement&template=feature_request.md` pre-filled. Opens: `https://github.com/Kokoabassplayer/fx-alert/issues/new?labels=enhancement&template=feature_request.md&title=%5BFEATURE%5D+`
+
+5. **General Feedback** — Link to blank GitHub issue: `https://github.com/Kokoabassplayer/fx-alert/issues/new`
+
+Each section uses the existing heading style (`text-lg font-semibold text-foreground`) and body text style (`text-sm text-muted-foreground leading-relaxed`) matching privacy/terms pages.
+
+External links (GitHub) use `target="_blank" rel="noopener noreferrer"` with `text-primary hover:underline` styling, consistent with privacy page's external links.
+
+### Footer Update (`src/components/site-footer.tsx`)
+
+Add "Contact" link between "Privacy" and "Terms" in the footer nav, following the existing `Link` component pattern.
+
+## Out of Scope
+
+- GitHub issue templates (bug_report.md, feature_request.md) — the links work without them; templates can be added later
+- Contact form with backend — YAGNI; email + GitHub Issues cover all needs
+- Social media links
+- Rate/review widget
+- Analytics tracking on contact link clicks
+
+## Success Criteria
+
+- `/contact` loads and displays all sections
+- All GitHub links open to the correct repo with correct labels
+- Email link opens mail client with correct address
+- Footer includes Contact link that navigates to `/contact`
+- `npm run typecheck` passes
+- Visual consistency with privacy/terms/about pages

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -4,7 +4,7 @@ import { APP_CONFIG } from '@/lib/constants';
 
 export const metadata: Metadata = {
   title: 'Contact Us - FX Alert',
-  description: 'Get in touch with FX Alert. Report bugs, request features, or send us feedback via GitHub Issues.',
+  description: 'Get in touch with FX Alert. Report bugs, request features, or send us feedback via email or GitHub.',
 };
 
 export default function ContactPage() {
@@ -18,6 +18,16 @@ export default function ContactPage() {
         <p className="text-sm text-muted-foreground leading-relaxed">
           Have a question, found a bug, or want to request a feature? Here&apos;s how to reach us.
           We use GitHub Issues to track feedback so nothing gets lost.
+        </p>
+      </section>
+
+      <section>
+        <h2 className="text-lg font-semibold text-foreground mb-2">Email</h2>
+        <p className="text-sm text-muted-foreground leading-relaxed">
+          For general inquiries, reach us at{' '}
+          <a href={`mailto:${APP_CONFIG.EMAIL}`} className="text-primary hover:underline">
+            {APP_CONFIG.EMAIL}
+          </a>.
         </p>
       </section>
 

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -7,8 +7,6 @@ export const metadata: Metadata = {
   description: 'Get in touch with FX Alert. Report bugs, request features, or send us feedback via email or GitHub.',
 };
 
-const GITHUB_REPO = 'Kokoabassplayer/fx-alert';
-
 export default function ContactPage() {
   return (
     <LegalLayout
@@ -39,7 +37,7 @@ export default function ContactPage() {
           Found something broken? Open a bug report on GitHub and we&apos;ll look into it.
         </p>
         <a
-          href={`https://github.com/${GITHUB_REPO}/issues/new?labels=bug&template=bug_report.md&title=%5BBUG%5D+`}
+          href={`https://github.com/${APP_CONFIG.GITHUB_REPO}/issues/new?labels=bug&template=bug_report.md&title=%5BBUG%5D+`}
           target="_blank"
           rel="noopener noreferrer"
           className="inline-block mt-2 text-sm text-primary hover:underline"
@@ -54,7 +52,7 @@ export default function ContactPage() {
           Have an idea that would make FX Alert better? We&apos;d love to hear it.
         </p>
         <a
-          href={`https://github.com/${GITHUB_REPO}/issues/new?labels=enhancement&template=feature_request.md&title=%5BFEATURE%5D+`}
+          href={`https://github.com/${APP_CONFIG.GITHUB_REPO}/issues/new?labels=enhancement&template=feature_request.md&title=%5BFEATURE%5D+`}
           target="_blank"
           rel="noopener noreferrer"
           className="inline-block mt-2 text-sm text-primary hover:underline"
@@ -69,7 +67,7 @@ export default function ContactPage() {
           Anything else on your mind? Open a general issue on GitHub.
         </p>
         <a
-          href={`https://github.com/${GITHUB_REPO}/issues/new`}
+          href={`https://github.com/${APP_CONFIG.GITHUB_REPO}/issues/new`}
           target="_blank"
           rel="noopener noreferrer"
           className="inline-block mt-2 text-sm text-primary hover:underline"

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,0 +1,82 @@
+import type { Metadata } from 'next';
+import { LegalLayout } from '@/components/legal-layout';
+import { APP_CONFIG } from '@/lib/constants';
+
+export const metadata: Metadata = {
+  title: 'Contact Us - FX Alert',
+  description: 'Get in touch with FX Alert. Report bugs, request features, or send us feedback via email or GitHub.',
+};
+
+const GITHUB_REPO = 'Kokoabassplayer/fx-alert';
+
+export default function ContactPage() {
+  return (
+    <LegalLayout
+      title="Contact Us"
+      description={metadata.description || ''}
+    >
+      <section>
+        <h2 className="text-lg font-semibold text-foreground mb-2">Get in Touch</h2>
+        <p className="text-sm text-muted-foreground leading-relaxed">
+          Have a question, found a bug, or want to request a feature? Here&apos;s how to reach us.
+          We use GitHub Issues to track feedback so nothing gets lost.
+        </p>
+      </section>
+
+      <section>
+        <h2 className="text-lg font-semibold text-foreground mb-2">Email</h2>
+        <p className="text-sm text-muted-foreground leading-relaxed">
+          For general inquiries, reach us at{' '}
+          <a href={`mailto:${APP_CONFIG.EMAIL}`} className="text-primary hover:underline">
+            {APP_CONFIG.EMAIL}
+          </a>.
+        </p>
+      </section>
+
+      <section>
+        <h2 className="text-lg font-semibold text-foreground mb-2">Report a Bug</h2>
+        <p className="text-sm text-muted-foreground leading-relaxed">
+          Found something broken? Open a bug report on GitHub and we&apos;ll look into it.
+        </p>
+        <a
+          href={`https://github.com/${GITHUB_REPO}/issues/new?labels=bug&template=bug_report.md&title=%5BBUG%5D+`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-block mt-2 text-sm text-primary hover:underline"
+        >
+          Open a Bug Report →
+        </a>
+      </section>
+
+      <section>
+        <h2 className="text-lg font-semibold text-foreground mb-2">Request a Feature</h2>
+        <p className="text-sm text-muted-foreground leading-relaxed">
+          Have an idea that would make FX Alert better? We&apos;d love to hear it.
+        </p>
+        <a
+          href={`https://github.com/${GITHUB_REPO}/issues/new?labels=enhancement&template=feature_request.md&title=%5BFEATURE%5D+`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-block mt-2 text-sm text-primary hover:underline"
+        >
+          Request a Feature →
+        </a>
+      </section>
+
+      <section>
+        <h2 className="text-lg font-semibold text-foreground mb-2">General Feedback</h2>
+        <p className="text-sm text-muted-foreground leading-relaxed">
+          Anything else on your mind? Open a general issue on GitHub.
+        </p>
+        <a
+          href={`https://github.com/${GITHUB_REPO}/issues/new`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-block mt-2 text-sm text-primary hover:underline"
+        >
+          Open an Issue →
+        </a>
+      </section>
+    </LegalLayout>
+  );
+}

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -4,7 +4,7 @@ import { APP_CONFIG } from '@/lib/constants';
 
 export const metadata: Metadata = {
   title: 'Contact Us - FX Alert',
-  description: 'Get in touch with FX Alert. Report bugs, request features, or send us feedback via email or GitHub.',
+  description: 'Get in touch with FX Alert. Report bugs, request features, or send us feedback via GitHub Issues.',
 };
 
 export default function ContactPage() {
@@ -18,16 +18,6 @@ export default function ContactPage() {
         <p className="text-sm text-muted-foreground leading-relaxed">
           Have a question, found a bug, or want to request a feature? Here&apos;s how to reach us.
           We use GitHub Issues to track feedback so nothing gets lost.
-        </p>
-      </section>
-
-      <section>
-        <h2 className="text-lg font-semibold text-foreground mb-2">Email</h2>
-        <p className="text-sm text-muted-foreground leading-relaxed">
-          For general inquiries, reach us at{' '}
-          <a href={`mailto:${APP_CONFIG.EMAIL}`} className="text-primary hover:underline">
-            {APP_CONFIG.EMAIL}
-          </a>.
         </p>
       </section>
 

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -2,79 +2,71 @@ import type { Metadata } from 'next';
 import { LegalLayout } from '@/components/legal-layout';
 import { APP_CONFIG } from '@/lib/constants';
 
+const GITHUB_ISSUES_BASE = `https://github.com/${APP_CONFIG.GITHUB_REPO}/issues/new`;
+
+const contactSections = [
+  {
+    heading: 'Get in Touch',
+    body: "Have a question, found a bug, or want to request a feature? Here's how to reach us. We use GitHub Issues to track feedback so nothing gets lost.",
+  },
+  {
+    heading: 'Email',
+    body: 'For general inquiries, reach us at',
+    href: `mailto:${APP_CONFIG.EMAIL}`,
+    linkText: APP_CONFIG.EMAIL,
+  },
+  {
+    heading: 'Report a Bug',
+    body: "Found something broken? Open a bug report on GitHub and we'll look into it.",
+    href: `${GITHUB_ISSUES_BASE}?labels=bug&template=bug_report.md&title=%5BBUG%5D+`,
+    linkText: 'Open a Bug Report →',
+    external: true,
+  },
+  {
+    heading: 'Request a Feature',
+    body: "Have an idea that would make FX Alert better? We'd love to hear it.",
+    href: `${GITHUB_ISSUES_BASE}?labels=enhancement&template=feature_request.md&title=%5BFEATURE%5D+`,
+    linkText: 'Request a Feature →',
+    external: true,
+  },
+  {
+    heading: 'General Feedback',
+    body: 'Anything else on your mind? Open a general issue on GitHub.',
+    href: GITHUB_ISSUES_BASE,
+    linkText: 'Open an Issue →',
+    external: true,
+  },
+];
+
 export const metadata: Metadata = {
-  title: 'Contact Us - FX Alert',
-  description: 'Get in touch with FX Alert. Report bugs, request features, or send us feedback via email or GitHub.',
+  title: `Contact Us - ${APP_CONFIG.NAME}`,
+  description: `Get in touch with ${APP_CONFIG.NAME}. Report bugs, request features, or send us feedback via email or GitHub.`,
 };
 
 export default function ContactPage() {
   return (
-    <LegalLayout
-      title="Contact Us"
-      description={metadata.description || ''}
-    >
-      <section>
-        <h2 className="text-lg font-semibold text-foreground mb-2">Get in Touch</h2>
-        <p className="text-sm text-muted-foreground leading-relaxed">
-          Have a question, found a bug, or want to request a feature? Here&apos;s how to reach us.
-          We use GitHub Issues to track feedback so nothing gets lost.
-        </p>
-      </section>
-
-      <section>
-        <h2 className="text-lg font-semibold text-foreground mb-2">Email</h2>
-        <p className="text-sm text-muted-foreground leading-relaxed">
-          For general inquiries, reach us at{' '}
-          <a href={`mailto:${APP_CONFIG.EMAIL}`} className="text-primary hover:underline">
-            {APP_CONFIG.EMAIL}
-          </a>.
-        </p>
-      </section>
-
-      <section>
-        <h2 className="text-lg font-semibold text-foreground mb-2">Report a Bug</h2>
-        <p className="text-sm text-muted-foreground leading-relaxed">
-          Found something broken? Open a bug report on GitHub and we&apos;ll look into it.
-        </p>
-        <a
-          href={`https://github.com/${APP_CONFIG.GITHUB_REPO}/issues/new?labels=bug&template=bug_report.md&title=%5BBUG%5D+`}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="inline-block mt-2 text-sm text-primary hover:underline"
-        >
-          Open a Bug Report →
-        </a>
-      </section>
-
-      <section>
-        <h2 className="text-lg font-semibold text-foreground mb-2">Request a Feature</h2>
-        <p className="text-sm text-muted-foreground leading-relaxed">
-          Have an idea that would make FX Alert better? We&apos;d love to hear it.
-        </p>
-        <a
-          href={`https://github.com/${APP_CONFIG.GITHUB_REPO}/issues/new?labels=enhancement&template=feature_request.md&title=%5BFEATURE%5D+`}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="inline-block mt-2 text-sm text-primary hover:underline"
-        >
-          Request a Feature →
-        </a>
-      </section>
-
-      <section>
-        <h2 className="text-lg font-semibold text-foreground mb-2">General Feedback</h2>
-        <p className="text-sm text-muted-foreground leading-relaxed">
-          Anything else on your mind? Open a general issue on GitHub.
-        </p>
-        <a
-          href={`https://github.com/${APP_CONFIG.GITHUB_REPO}/issues/new`}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="inline-block mt-2 text-sm text-primary hover:underline"
-        >
-          Open an Issue →
-        </a>
-      </section>
+    <LegalLayout title="Contact Us" description={metadata.description ?? ''}>
+      {contactSections.map(({ heading, body, href, linkText, external }) => (
+        <section key={heading}>
+          <h2 className="text-lg font-semibold text-foreground mb-2">{heading}</h2>
+          <p className="text-sm text-muted-foreground leading-relaxed">
+            {body}
+            {href && (
+              <>
+                {' '}
+                <a
+                  href={href}
+                  {...(external ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
+                  className="text-primary hover:underline"
+                >
+                  {linkText}
+                </a>
+                {heading === 'Email' && '.'}
+              </>
+            )}
+          </p>
+        </section>
+      ))}
     </LegalLayout>
   );
 }

--- a/src/components/site-footer.tsx
+++ b/src/components/site-footer.tsx
@@ -50,6 +50,10 @@ export function SiteFooter() {
             Privacy
           </Link>
           <span className="text-muted-foreground">•</span>
+          <Link href="/contact" className="text-muted-foreground hover:text-primary transition-colors">
+            Contact
+          </Link>
+          <span className="text-muted-foreground">•</span>
           <Link href="/terms" className="text-muted-foreground hover:text-primary transition-colors">
             Terms
           </Link>

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -6,5 +6,6 @@ export const APP_CONFIG = {
   NAME: 'FX Alert',
   EMAIL: 'kokoabassplayer+fxalert@gmail.com',
   DEVELOPER: 'Nuttapong Buttprom',
+  GITHUB_REPO: 'Kokoabassplayer/fx-alert',
   LEGAL_LAST_UPDATED: '2026-03-10',
 } as const;


### PR DESCRIPTION
## Summary
- Add `/contact` page with email, bug report, feature request, and general feedback sections
- All GitHub Issues links pre-fill labels (bug/enhancement) and templates
- Add Contact link to footer navigation between Privacy and Terms
- Move `GITHUB_REPO` to `APP_CONFIG` for centralized constants

## Test plan
- [x] `/contact` loads with all 5 sections
- [x] Email link opens mail client with correct address
- [x] GitHub links open correct repo with correct labels/templates
- [x] Footer Contact link navigates to `/contact`
- [x] `npm run typecheck` passes (no new errors)
- [x] Visual consistency with privacy/terms/about pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)