### PR TITLE
Add international and Thai gold rate choices

### DIFF
--- a/src/app/alerts/page.tsx
+++ b/src/app/alerts/page.tsx
@@ -13,6 +13,7 @@ import { AlertForm } from '@/components/alert-form';
 import { AlertList } from '@/components/alert-list';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { trackAlertCreated } from '@/lib/analytics';
+import { formatRate } from '@/lib/rate-format';
 
 const DEFAULT_NOTIFICATION_METHOD = 'email' as const;
 
@@ -62,7 +63,7 @@ export default function AlertsPage() {
         const pair = `${alert.fromCurrency}/${alert.toCurrency}`;
         toast({
           title: "🔔 Alert Triggered!",
-          description: `${pair} is ${currentRate.toFixed(2)} (${alert.condition} ${alert.threshold.toFixed(2)})`,
+          description: `${pair} is ${formatRate(currentRate)} (${alert.condition} ${formatRate(alert.threshold)})`,
           variant: "default",
         });
       });
@@ -129,7 +130,7 @@ export default function AlertsPage() {
     trackAlertCreated(fromCurrency, toCurrency, threshold, condition, DEFAULT_NOTIFICATION_METHOD);
     toast({
       title: "Alert Created",
-      description: `You'll be notified when ${fromCurrency}/${toCurrency} goes ${condition} ${threshold.toFixed(2)}.`,
+      description: `You'll be notified when ${fromCurrency}/${toCurrency} goes ${condition} ${formatRate(threshold)}.`,
     });
 
     // Fetch current rate for the new pair
@@ -204,7 +205,7 @@ export default function AlertsPage() {
                 Active alerts are checked automatically every 30 minutes. You can also check manually anytime.
               </p>
               <p className="text-xs text-muted-foreground mt-1">
-                Note: Exchange rate data from Frankfurter API updates once per weekday around 10:00 PM Thai time.
+                Note: Fiat rates use Frankfurter v1. XAU uses Frankfurter v2; THG is a derived 96.5% Thai gold reference, not a retail buy or sell quote.
               </p>
             </div>
           </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -26,6 +26,7 @@ import { HeroBandCard } from "@/components/hero-band-card";
 import { ChevronDown } from "lucide-react";
 import type { RealTimeRateResponse } from "@/lib/currency-api";
 import type { ThresholdBand } from "@/lib/dynamic-analysis";
+import { formatRate } from '@/lib/rate-format';
 
 // Period options with lookup map for O(1) label access
 const PERIOD_OPTIONS = [
@@ -153,7 +154,7 @@ const UsdThbMonitorPage: FC = () => {
             <div>
               <h3 className="text-lg font-semibold mb-1">
                 {pairAnalysisData?.distribution_statistics.mean
-                  ? `${selectedFromCurrency}/${selectedToCurrency} averages ${pairAnalysisData.distribution_statistics.mean.toFixed(2)}. Get notified when it hits your target.`
+                  ? `${selectedFromCurrency}/${selectedToCurrency} averages ${formatRate(pairAnalysisData.distribution_statistics.mean)}. Get notified when it hits your target.`
                   : 'Set rate alerts and get notified instantly'}
               </h3>
               <p className="text-sm text-primary-foreground/80">
@@ -189,6 +190,12 @@ const UsdThbMonitorPage: FC = () => {
             toCurrency={selectedToCurrency}
             isLoading={isAnalysisLoading}
           />
+
+          {(selectedFromCurrency === 'THG' || selectedToCurrency === 'THG') && (
+            <p className="rounded-lg bg-amber-50 px-3 py-2 text-xs text-amber-800 dark:bg-amber-950/20 dark:text-amber-200">
+              THG is a derived 96.5% Thai gold reference per baht-weight, not a retail buy or sell quote.
+            </p>
+          )}
 
           {/* Period Pills */}
           <div className="flex gap-2 overflow-x-auto pb-1 -mx-4 px-4 [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden">
@@ -316,10 +323,10 @@ const UsdThbMonitorPage: FC = () => {
         <div className="mt-8 mb-6">
           <h2 className="text-sm font-semibold text-foreground mb-1">Data Source & Analysis</h2>
           <p className="text-xs text-muted-foreground">
-            Exchange rate data is sourced from the Frankfurter API. Rate bands, probabilities, and suggestions are based on an analysis of historical USD/THB data (2010-2024) and simulated monthly volatility. See full analysis details below the chart. Exchange rate predictions are inherently uncertain.
+            Fiat rates use Frankfurter v1. XAU gold rates use Frankfurter v2. THG is a derived reference for one 96.5% Thai gold bar baht-weight (15.244 g), calculated from XAU; it is not a Gold Traders Association retail buy or sell price.
           </p>
           <p className="text-xs text-muted-foreground mt-1">
-            Statistical analysis and rate insights generated from historical Frankfurter API data.
+            Rate bands and insights are calculated from the selected pair&apos;s historical Frankfurter data. Exchange-rate and gold-price predictions are inherently uncertain.
           </p>
         </div>
 

--- a/src/components/alert-form.tsx
+++ b/src/components/alert-form.tsx
@@ -19,17 +19,16 @@ import {
 } from '@/components/ui/popover';
 import { Switch } from '@/components/ui/switch';
 import type { AlertCondition } from '@/lib/alerts-types';
+import {
+  COMMON_RATE_ASSETS,
+  getCompatibleFallbackAsset,
+  isSupportedRatePair,
+} from '@/lib/rate-assets';
+import { formatRate } from '@/lib/rate-format';
 
-const COMMON_CURRENCIES = [
-  { code: 'USD', name: 'US Dollar' },
-  { code: 'THB', name: 'Thai Baht' },
-  { code: 'EUR', name: 'Euro' },
-  { code: 'GBP', name: 'British Pound' },
-  { code: 'JPY', name: 'Japanese Yen' },
-  { code: 'SGD', name: 'Singapore Dollar' },
-  { code: 'AUD', name: 'Australian Dollar' },
-  { code: 'CHF', name: 'Swiss Franc' },
-];
+const COMMON_RATE_ASSET_MAP = Object.fromEntries(
+  COMMON_RATE_ASSETS.map(asset => [asset.code, asset.name]),
+);
 
 interface AlertFormProps {
   onSubmit: (
@@ -48,14 +47,14 @@ export function AlertForm({ onSubmit, currentRate, currencyPair }: AlertFormProp
   const [toCurrency, setToCurrency] = useState(currencyPair?.to || 'THB');
   const [condition, setCondition] = useState<AlertCondition>('above');
   const [threshold, setThreshold] = useState(currentRate?.toString() || '');
-  const [sameCurrencyError, setSameCurrencyError] = useState(false);
+  const [pairError, setPairError] = useState(false);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
 
     // Validate
-    if (fromCurrency === toCurrency) {
-      setSameCurrencyError(true);
+    if (!isSupportedRatePair(fromCurrency, toCurrency)) {
+      setPairError(true);
       return;
     }
 
@@ -71,14 +70,32 @@ export function AlertForm({ onSubmit, currentRate, currencyPair }: AlertFormProp
     setToCurrency('THB');
     setCondition('above');
     setThreshold('');
-    setSameCurrencyError(false);
+    setPairError(false);
     setOpen(false);
   };
 
   const handleThresholdFromCurrent = () => {
     if (currentRate) {
-      setThreshold(currentRate.toFixed(2));
+      setThreshold(String(currentRate));
     }
+  };
+
+  const handleFromCurrencyChange = (newFrom: string) => {
+    setPairError(false);
+    if (!isSupportedRatePair(newFrom, toCurrency)) {
+      const fallback = getCompatibleFallbackAsset(newFrom, COMMON_RATE_ASSET_MAP);
+      if (fallback) setToCurrency(fallback);
+    }
+    setFromCurrency(newFrom);
+  };
+
+  const handleToCurrencyChange = (newTo: string) => {
+    setPairError(false);
+    if (!isSupportedRatePair(fromCurrency, newTo)) {
+      const fallback = getCompatibleFallbackAsset(newTo, COMMON_RATE_ASSET_MAP);
+      if (fallback) setFromCurrency(fallback);
+    }
+    setToCurrency(newTo);
   };
 
   return (
@@ -105,14 +122,14 @@ export function AlertForm({ onSubmit, currentRate, currencyPair }: AlertFormProp
 
           {/* From Currency */}
           <div className="space-y-2">
-            <Label htmlFor="from-currency" className="text-xs">From Currency</Label>
-            <Select value={fromCurrency} onValueChange={setFromCurrency}>
+            <Label htmlFor="from-currency" className="text-xs">From Asset</Label>
+            <Select value={fromCurrency} onValueChange={handleFromCurrencyChange}>
               <SelectTrigger id="from-currency">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
-                {COMMON_CURRENCIES.map(currency => (
-                  <SelectItem key={currency.code} value={currency.code}>
+                {COMMON_RATE_ASSETS.map(currency => (
+                  <SelectItem key={currency.code} value={currency.code} disabled={!isSupportedRatePair(currency.code, toCurrency)}>
                     {currency.code} - {currency.name}
                   </SelectItem>
                 ))}
@@ -122,21 +139,21 @@ export function AlertForm({ onSubmit, currentRate, currencyPair }: AlertFormProp
 
           {/* To Currency */}
           <div className="space-y-2">
-            <Label htmlFor="to-currency" className="text-xs">To Currency</Label>
-            <Select value={toCurrency} onValueChange={setToCurrency}>
+            <Label htmlFor="to-currency" className="text-xs">To Asset</Label>
+            <Select value={toCurrency} onValueChange={handleToCurrencyChange}>
               <SelectTrigger id="to-currency">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
-                {COMMON_CURRENCIES.map(currency => (
-                  <SelectItem key={currency.code} value={currency.code}>
+                {COMMON_RATE_ASSETS.map(currency => (
+                  <SelectItem key={currency.code} value={currency.code} disabled={!isSupportedRatePair(fromCurrency, currency.code)}>
                     {currency.code} - {currency.name}
                   </SelectItem>
                 ))}
               </SelectContent>
             </Select>
-            {sameCurrencyError && (
-              <p className="text-xs text-destructive">Currencies must be different</p>
+            {pairError && (
+              <p className="text-xs text-destructive">Choose two different, non-equivalent assets.</p>
             )}
           </div>
 
@@ -163,7 +180,7 @@ export function AlertForm({ onSubmit, currentRate, currencyPair }: AlertFormProp
               <Input
                 id="threshold"
                 type="number"
-                step="0.01"
+                step="any"
                 placeholder="35.00"
                 value={threshold}
                 onChange={(e) => setThreshold(e.target.value)}
@@ -184,7 +201,12 @@ export function AlertForm({ onSubmit, currentRate, currencyPair }: AlertFormProp
             </div>
             {currentRate && (
               <p className="text-xs text-muted-foreground">
-                Current rate: {currentRate.toFixed(2)}
+                Current rate: {formatRate(currentRate)}
+              </p>
+            )}
+            {(fromCurrency === 'THG' || toCurrency === 'THG') && (
+              <p className="text-xs text-amber-700 dark:text-amber-300">
+                THG alerts use a derived reference price, not a Thai retail buy or sell quote.
               </p>
             )}
           </div>

--- a/src/components/alert-list.tsx
+++ b/src/components/alert-list.tsx
@@ -16,6 +16,7 @@ import {
   AlertDialogTrigger,
 } from '@/components/ui/alert-dialog';
 import type { RateAlert } from '@/lib/alerts-types';
+import { formatRate } from '@/lib/rate-format';
 
 interface AlertListProps {
   alerts: RateAlert[];
@@ -84,18 +85,18 @@ export function AlertList({ alerts, onToggle, onDelete, currentRates }: AlertLis
                     <span className={alert.condition === 'above' ? 'text-green-600' : 'text-amber-600'}>
                       {alert.condition}
                     </span>{' '}
-                    {alert.threshold.toFixed(2)}
+                    {formatRate(alert.threshold)}
                   </p>
                   <p className="text-xs text-muted-foreground truncate">
                     {alert.condition === 'above'
-                      ? `Notify when rate exceeds ${alert.threshold.toFixed(2)}`
-                      : `Notify when rate drops below ${alert.threshold.toFixed(2)}`}
+                      ? `Notify when rate exceeds ${formatRate(alert.threshold)}`
+                      : `Notify when rate drops below ${formatRate(alert.threshold)}`}
                   </p>
 
                   {/* Current Rate Display */}
                   {currentRate !== undefined && (
                     <p className="text-xs text-muted-foreground mt-1">
-                      Current: <span className="font-medium text-foreground">{currentRate.toFixed(2)}</span>
+                      Current: <span className="font-medium text-foreground">{formatRate(currentRate)}</span>
                       {alert.condition === 'above' && currentRate > alert.threshold && (
                         <span className="ml-1 text-green-600">(Above target!)</span>
                       )}

--- a/src/components/analysis-display.tsx
+++ b/src/components/analysis-display.tsx
@@ -9,6 +9,7 @@ import { type PairAnalysisData } from '@/lib/dynamic-analysis';
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Terminal, Info, Lightbulb } from 'lucide-react';
 import { useIsMobile } from "@/hooks/use-is-mobile";
+import { formatRate as formatAdaptiveRate } from '@/lib/rate-format';
 
 interface AnalysisDisplayProps {
   fromCurrency: string | null;
@@ -95,7 +96,7 @@ const AnalysisDisplay: React.FC<AnalysisDisplayProps> = ({
   const { trend_summary, distribution_statistics, threshold_bands } = pairAnalysisData;
   const stats = distribution_statistics; // Alias for convenience
 
-  const formatRate = (rate: number | null | undefined) => rate?.toFixed(4) || 'N/A';
+  const formatRate = (rate: number | null | undefined) => formatAdaptiveRate(rate);
   const formatPercent = (value: number | null | undefined) => value !== null && value !== undefined ? `≈ ${(value * 100).toFixed(1)} %` : 'N/A';
 
 

--- a/src/components/current-rate-display.tsx
+++ b/src/components/current-rate-display.tsx
@@ -29,6 +29,12 @@ import {
 } from "@/lib/bands";
 import { type PairAnalysisData, type ThresholdBand } from '@/lib/dynamic-analysis'; // Import new types
 import { getBadgeClassSoft } from '@/lib/band-styles';
+import {
+  getCompatibleFallbackAsset,
+  isGoldAsset,
+  isSupportedRatePair,
+} from '@/lib/rate-assets';
+import { formatRate } from '@/lib/rate-format';
 
 interface CurrentRateDisplayProps {
   alertPrefs: AlertPrefs;
@@ -79,15 +85,9 @@ const CurrentRateDisplay: FC<CurrentRateDisplayProps> = ({
       if (currencies) {
         setAvailableCurrencies(currencies);
         onCurrenciesChange?.(currencies);
-        if (!currencies[toCurrency] || fromCurrency === toCurrency) {
-          const validKeys = Object.keys(currencies);
-          if (validKeys.length > 0) {
-            let newTo = validKeys.find(k => k !== fromCurrency);
-            if (!newTo && validKeys.length > 0) newTo = validKeys[0];
-            if (newTo && newTo !== toCurrency) {
-              onToCurrencyChange(newTo);
-            }
-          }
+        if (!currencies[toCurrency] || !isSupportedRatePair(fromCurrency, toCurrency)) {
+          const newTo = getCompatibleFallbackAsset(fromCurrency, currencies);
+          if (newTo && newTo !== toCurrency) onToCurrencyChange(newTo);
         }
       } else {
         toast({
@@ -103,14 +103,16 @@ const CurrentRateDisplay: FC<CurrentRateDisplayProps> = ({
   // Effect for fetching the current rate (remains largely the same)
   const fetchRate = useCallback(async (currentFrom: string, currentTo: string) => {
     setIsLoading(true);
+    setCurrentRateData(null);
+    onRateDataChange?.(null);
     // Ensure from and to are different before fetching
     // This check is important here even if parent tries to manage it, as a safeguard
-    if (currentFrom === currentTo) {
+    if (!isSupportedRatePair(currentFrom, currentTo)) {
       if (Object.keys(availableCurrencies || {}).length > 1) { // Only show toast if there are other options
         toast({
           title: "Invalid Selection",
-          description: "From and To currencies cannot be the same. Please select different currencies.",
-          variant: "warning",
+          description: "Choose two different, non-equivalent assets.",
+          variant: "default",
         });
       }
       setIsLoading(false);
@@ -123,6 +125,8 @@ const CurrentRateDisplay: FC<CurrentRateDisplayProps> = ({
       setCurrentRateData(data);
       onRateDataChange?.(data);
     } else {
+      setCurrentRateData(null);
+      onRateDataChange?.(null);
       toast({
         title: "Error Fetching Rate",
         description: `Could not fetch the current ${currentFrom}/${currentTo} exchange rate. Please try again later.`,
@@ -130,19 +134,22 @@ const CurrentRateDisplay: FC<CurrentRateDisplayProps> = ({
       });
     }
     setIsLoading(false);
-  }, [toast]); // availableCurrencies removed as it's not directly used for decision here, only for initial setup
+  }, [availableCurrencies, onRateDataChange, toast]);
 
   useEffect(() => {
-    if (fromCurrency && toCurrency && fromCurrency !== toCurrency) {
+    if (isSupportedRatePair(fromCurrency, toCurrency)) {
       fetchRate(fromCurrency, toCurrency); // Use props directly
       const intervalId = setInterval(() => fetchRate(fromCurrency, toCurrency), REFRESH_INTERVAL_MS);
       return () => clearInterval(intervalId);
-    } else if (fromCurrency && toCurrency && fromCurrency === toCurrency) {
+    } else if (fromCurrency && toCurrency) {
       // If they are the same, clear current rate data and loading state, as fetchRate won't run
       setCurrentRateData(null);
+      onRateDataChange?.(null);
+      setCurrentDynamicBand(null);
+      onBandChange?.(null);
       setIsLoading(false);
     }
-  }, [fetchRate, fromCurrency, toCurrency]);
+  }, [fetchRate, fromCurrency, onBandChange, onRateDataChange, toCurrency]);
 
   // useEffect to classify the current rate against dynamic bands
   useEffect(() => {
@@ -211,11 +218,11 @@ const CurrentRateDisplay: FC<CurrentRateDisplayProps> = ({
 
 
       if (staticBandForToast && staticBandForToast.name && alertPrefs[staticBandForToast.name]) {
-        const currentBandName = staticBandForToast.name;
+        const currentBandName = String(staticBandForToast.name);
         if (currentBandName !== prevBandRef.current && ['EXTREME_LOW', 'EXTREME_HIGH', 'LOW', 'HIGH'].includes(currentBandName)) { // Example levels
            toast({
               title: `Rate Alert: ${staticBandForToast.displayName} Zone!`,
-              description: `${fromCurrency}/${toCurrency} at ${rate.toFixed(4)}. Suggestion: ${staticBandForToast.action}`,
+              description: `${fromCurrency}/${toCurrency} at ${formatRate(rate)}. Suggestion: ${staticBandForToast.action}`,
               variant: (currentBandName === 'EXTREME_LOW' || currentBandName === 'EXTREME_HIGH') ? 'destructive' : 'default',
               // className: staticBandForToast.colorConfig.toastClass // This needs to be mapped if using dynamic levels
            });
@@ -237,7 +244,7 @@ const CurrentRateDisplay: FC<CurrentRateDisplayProps> = ({
     onAlertPrefsChange({ ...alertPrefs, [bandName]: checked });
   };
 
-  const displayRate = rate !== undefined ? rate.toFixed(4) : "N/A";
+  const displayRate = formatRate(rate);
   const rateColorClass = currentDynamicBand ? "text-foreground" : "text-muted-foreground";
 
   const formatLastUpdatedDate = (date: Date | null): string => {
@@ -250,10 +257,15 @@ const CurrentRateDisplay: FC<CurrentRateDisplayProps> = ({
   };
 
   const getDataSourceLabel = (): string => {
+    if (dataSource === 'frankfurter-derived') return 'Derived reference';
+    if (dataSource === 'frankfurter-v2') return 'Gold reference';
     return 'Daily';
   };
 
   const getDataSourceBadgeClass = (): string => {
+    if (dataSource === 'frankfurter-derived') {
+      return 'bg-amber-100 text-amber-800 border-amber-300';
+    }
     return 'bg-blue-100 text-blue-800 border-blue-300';
   };
 
@@ -263,20 +275,16 @@ const CurrentRateDisplay: FC<CurrentRateDisplayProps> = ({
       <CardHeader className="bg-card/50">
         <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
           <CardTitle className="text-primary flex-shrink-0">
-            {fromCurrency} / {toCurrency} Exchange Rate
+            {fromCurrency} / {toCurrency} {isGoldAsset(fromCurrency) || isGoldAsset(toCurrency) ? 'Reference Rate' : 'Exchange Rate'}
           </CardTitle>
           {isLoading && !currentRateData && <Loader2 className="h-5 w-5 animate-spin text-primary sm:ml-auto" />}
           <div className="flex gap-2 items-center mt-2 sm:mt-0 flex-wrap sm:flex-nowrap">
             <Select 
               value={fromCurrency} 
               onValueChange={(newFromValue) => {
-                if (newFromValue === toCurrency) {
-                  // If selected 'from' is same as current 'to', try to change 'to'
-                  const otherCurrencies = Object.keys(availableCurrencies || {}).filter(c => c !== newFromValue);
-                  if (otherCurrencies.length > 0) {
-                    onToCurrencyChange(otherCurrencies[0]); // Suggest new 'to'
-                  }
-                  // If no other currencies, parent will handle (or fetchRate will block)
+                if (!isSupportedRatePair(newFromValue, toCurrency) && availableCurrencies) {
+                  const fallback = getCompatibleFallbackAsset(newFromValue, availableCurrencies);
+                  if (fallback) onToCurrencyChange(fallback);
                 }
                 onFromCurrencyChange(newFromValue);
               }}
@@ -286,7 +294,7 @@ const CurrentRateDisplay: FC<CurrentRateDisplayProps> = ({
               </SelectTrigger>
               <SelectContent>
                 {availableCurrencies && Object.entries(availableCurrencies).map(([code, name]) => (
-                  <SelectItem key={code} value={code} textValue={code} disabled={code === toCurrency && Object.keys(availableCurrencies || {}).length > 1}>
+                  <SelectItem key={code} value={code} textValue={code} disabled={!isSupportedRatePair(code, toCurrency)}>
                     {code} - {name}
                   </SelectItem>
                 ))}
@@ -296,13 +304,9 @@ const CurrentRateDisplay: FC<CurrentRateDisplayProps> = ({
             <Select 
               value={toCurrency} 
               onValueChange={(newToValue) => {
-                if (newToValue === fromCurrency) {
-                  // If selected 'to' is same as current 'from', try to change 'from'
-                  const otherCurrencies = Object.keys(availableCurrencies || {}).filter(c => c !== newToValue);
-                  if (otherCurrencies.length > 0) {
-                     onFromCurrencyChange(otherCurrencies[0]); // Suggest new 'from'
-                  }
-                  // If no other currencies, parent will handle (or fetchRate will block)
+                if (!isSupportedRatePair(fromCurrency, newToValue) && availableCurrencies) {
+                  const fallback = getCompatibleFallbackAsset(newToValue, availableCurrencies);
+                  if (fallback) onFromCurrencyChange(fallback);
                 }
                 onToCurrencyChange(newToValue);
               }}
@@ -312,7 +316,7 @@ const CurrentRateDisplay: FC<CurrentRateDisplayProps> = ({
               </SelectTrigger>
               <SelectContent>
                 {availableCurrencies && Object.entries(availableCurrencies).map(([code, name]) => (
-                  <SelectItem key={code} value={code} textValue={code} disabled={code === fromCurrency && Object.keys(availableCurrencies || {}).length > 1}>
+                  <SelectItem key={code} value={code} textValue={code} disabled={!isSupportedRatePair(fromCurrency, code)}>
                     {code} - {name}
                   </SelectItem>
                 ))}
@@ -354,7 +358,7 @@ const CurrentRateDisplay: FC<CurrentRateDisplayProps> = ({
                   <div className="text-left sm:text-right mt-1 sm:mt-0">
                      {currentDynamicBand.range.min !== null && currentDynamicBand.range.max !== null && (
                        <p className="text-xs text-muted-foreground">
-                         Range: {currentDynamicBand.range.min.toFixed(4)} - {currentDynamicBand.range.max.toFixed(4)}
+                         Range: {formatRate(currentDynamicBand.range.min)} - {formatRate(currentDynamicBand.range.max)}
                        </p>
                      )}
                     {currentDynamicBand.probability !== null && (
@@ -392,7 +396,7 @@ const CurrentRateDisplay: FC<CurrentRateDisplayProps> = ({
                      <>
                        <Info className="h-8 w-8 text-muted-foreground/50" />
                        <p>Rate band information will appear here.</p>
-                       { !currentDynamicBand && rate !== undefined && <p className="text-xs">Current rate {rate.toFixed(4)} not falling into defined bands.</p> }
+                       { !currentDynamicBand && rate !== undefined && <p className="text-xs">Current rate {formatRate(rate)} not falling into defined bands.</p> }
                      </>
                  }
                 </div>
@@ -400,6 +404,11 @@ const CurrentRateDisplay: FC<CurrentRateDisplayProps> = ({
           </div>
         </div>
       </CardContent>
+      {(fromCurrency === 'THG' || toCurrency === 'THG') && (
+        <CardFooter className="bg-amber-50/60 dark:bg-amber-950/20 text-xs text-muted-foreground">
+          THG is a derived reference for one 96.5% Thai gold bar baht-weight (15.244 g), calculated from XAU. It is not a Gold Traders Association retail buy or sell price.
+        </CardFooter>
+      )}
       {/* 
         The CardFooter containing the "Alert & Chart Band Preferences" has been removed 
         as per the user's request because these settings are no longer needed.

--- a/src/components/current-rate-display.tsx
+++ b/src/components/current-rate-display.tsx
@@ -73,6 +73,7 @@ const CurrentRateDisplay: FC<CurrentRateDisplayProps> = ({
 
   // Internal state for availableCurrencies is still needed
   const [availableCurrencies, setAvailableCurrencies] = useState<{ [key: string]: string } | null>(null);
+  const availableCurrenciesRef = useRef<{ [key: string]: string }>({});
 
   const rate = currentRateData?.rate;
   const lastUpdated = currentRateData?.timestamp ? new Date(currentRateData.timestamp) : null;
@@ -83,6 +84,7 @@ const CurrentRateDisplay: FC<CurrentRateDisplayProps> = ({
     const getAvailableCurrencies = async () => {
       const currencies = await fetchAvailableCurrencies();
       if (currencies) {
+        availableCurrenciesRef.current = currencies;
         setAvailableCurrencies(currencies);
         onCurrenciesChange?.(currencies);
         if (!currencies[toCurrency] || !isSupportedRatePair(fromCurrency, toCurrency)) {
@@ -108,7 +110,7 @@ const CurrentRateDisplay: FC<CurrentRateDisplayProps> = ({
     // Ensure from and to are different before fetching
     // This check is important here even if parent tries to manage it, as a safeguard
     if (!isSupportedRatePair(currentFrom, currentTo)) {
-      if (Object.keys(availableCurrencies || {}).length > 1) { // Only show toast if there are other options
+      if (Object.keys(availableCurrenciesRef.current).length > 1) { // Only show toast if there are other options
         toast({
           title: "Invalid Selection",
           description: "Choose two different, non-equivalent assets.",
@@ -134,7 +136,7 @@ const CurrentRateDisplay: FC<CurrentRateDisplayProps> = ({
       });
     }
     setIsLoading(false);
-  }, [availableCurrencies, onRateDataChange, toast]);
+  }, [onRateDataChange, toast]);
 
   useEffect(() => {
     if (isSupportedRatePair(fromCurrency, toCurrency)) {

--- a/src/components/hero-band-card.tsx
+++ b/src/components/hero-band-card.tsx
@@ -3,6 +3,7 @@
 import { Badge } from "@/components/ui/badge";
 import type { ThresholdBand } from "@/lib/dynamic-analysis";
 import { getBandBorderColor, getBandBgColor, getBadgeClassBold } from "@/lib/band-styles";
+import { formatRate } from "@/lib/rate-format";
 
 interface HeroBandCardProps {
   band: ThresholdBand | null;
@@ -43,8 +44,8 @@ export function HeroBandCard({
       )}
       {band.range.min !== null && band.range.max !== null && (
         <p className="text-xs text-muted-foreground mt-2">
-          {fromCurrency}/{toCurrency} range: {band.range.min.toFixed(4)} —{" "}
-          {band.range.max.toFixed(4)}
+          {fromCurrency}/{toCurrency} range: {formatRate(band.range.min)} —{" "}
+          {formatRate(band.range.max)}
         </p>
       )}
     </div>

--- a/src/components/history-chart-display.tsx
+++ b/src/components/history-chart-display.tsx
@@ -21,6 +21,7 @@ import {
 import { type PairAnalysisData, type ThresholdBand as DynamicThresholdBand } from '@/lib/dynamic-analysis'; // Import PairAnalysisData
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { useIsMobile } from "@/hooks/use-is-mobile";
+import { formatRate, getRateDecimalPlaces } from '@/lib/rate-format';
 
 
 interface HistoryChartDisplayProps {
@@ -142,7 +143,7 @@ const HistoryChartDisplay: FC<HistoryChartDisplayProps> = ({
           reason: dynamicBand.reason,
           exampleAction: "", // Not available in DynamicThresholdBand
           probability: dynamicBand.probability !== null ? `${(dynamicBand.probability * 100).toFixed(0)}%` : "N/A",
-          rangeDisplay: `${dynamicBand.range.min?.toFixed(4) ?? '...'} - ${dynamicBand.range.max?.toFixed(4) ?? '...'}`,
+          rangeDisplay: `${formatRate(dynamicBand.range.min, '...')} - ${formatRate(dynamicBand.range.max, '...')}`,
           colorConfig: colorConfig,
         };
       });
@@ -196,8 +197,8 @@ const HistoryChartDisplay: FC<HistoryChartDisplayProps> = ({
       chartBands.forEach(band => {
         const bandNameKey = band.name as BandName; // Assuming band.name is a valid BandName or mapped to one
         if (alertPrefs[bandNameKey] !== false) { // Show if true or undefined (default to show)
-          if (band.minRate !== -Infinity && band.minRate !== undefined) activeBandNumericBoundaries.push(band.minRate);
-          if (band.maxRate !== Infinity && band.maxRate !== undefined) activeBandNumericBoundaries.push(band.maxRate);
+          if (band.minRate !== -Infinity && band.minRate !== undefined && band.minRate !== null) activeBandNumericBoundaries.push(band.minRate);
+          if (band.maxRate !== Infinity && band.maxRate !== undefined && band.maxRate !== null) activeBandNumericBoundaries.push(band.maxRate);
         }
       });
     }
@@ -235,7 +236,7 @@ const HistoryChartDisplay: FC<HistoryChartDisplayProps> = ({
     padding = isFinite(padding) ? padding : 0.05; // Ensure padding is valid
 
     const typicalValue = (overallMax + overallMin) / 2;
-    const decimals = typicalValue > 50 ? 2 : 4; // Fewer decimals for high-value pairs like JPY
+    const decimals = getRateDecimalPlaces(typicalValue);
 
     return [parseFloat((overallMin - padding).toFixed(decimals)), parseFloat((overallMax + padding).toFixed(decimals))] as [number, number];
 
@@ -255,7 +256,7 @@ const HistoryChartDisplay: FC<HistoryChartDisplayProps> = ({
       return (
         <div className="bg-background/90 backdrop-blur-sm p-3 border border-border rounded-lg shadow-xl">
           <p className="text-xs text-muted-foreground">{`Date: ${label}`}</p>
-          <p className="text-sm text-primary font-semibold">{`${toCurrency}/${fromCurrency}: ${typeof rateValue === 'number' ? rateValue.toFixed(4) : 'N/A'}`}</p>
+          <p className="text-sm text-primary font-semibold">{`${toCurrency}/${fromCurrency}: ${formatRate(typeof rateValue === 'number' ? rateValue : null)}`}</p>
           {bandForTooltip && (
             <div className="mt-1">
               <Badge className={`${bandForTooltip.colorConfig.badgeClass} text-xs px-2 py-0.5`}>{bandForTooltip.displayName}</Badge>
@@ -309,7 +310,7 @@ const HistoryChartDisplay: FC<HistoryChartDisplayProps> = ({
             <span className="text-xs">Tap chart to inspect</span>
             {tappedPoint && (
               <span className="text-xs">
-                <span className="font-semibold text-primary">{tappedPoint.rate.toFixed(4)}</span>
+                <span className="font-semibold text-primary">{formatRate(tappedPoint.rate)}</span>
                 <span className="ml-1.5">{tappedPoint.date}</span>
               </span>
             )}
@@ -346,7 +347,7 @@ const HistoryChartDisplay: FC<HistoryChartDisplayProps> = ({
               />
               <YAxis
                 domain={yAxisDomain}
-                tickFormatter={(value) => typeof value === 'number' ? value.toFixed(toCurrency === 'JPY' ? 3 : 4) : ''} // More precision for JPY like pairs
+                tickFormatter={(value) => typeof value === 'number' ? formatRate(value, '') : ''}
                 tick={{ fontSize: 10, fill: 'hsl(var(--muted-foreground))' }}
                 tickLine={{ stroke: 'hsl(var(--border))' }}
                 axisLine={{ strokeWidth: 1, stroke: 'hsl(var(--border))' }}
@@ -467,4 +468,3 @@ const HistoryChartDisplay: FC<HistoryChartDisplayProps> = ({
 };
 
 export default HistoryChartDisplay;
-

--- a/src/components/mobile-sticky-bar.tsx
+++ b/src/components/mobile-sticky-bar.tsx
@@ -11,6 +11,8 @@ import {
 import type { ThresholdBand } from "@/lib/dynamic-analysis";
 import type { RealTimeRateResponse } from "@/lib/currency-api";
 import { getBadgeClassBold, getBandIndicator } from "@/lib/band-styles";
+import { isSupportedRatePair } from "@/lib/rate-assets";
+import { formatRate } from "@/lib/rate-format";
 
 interface MobileStickyBarProps {
   rateData: RealTimeRateResponse | null;
@@ -34,7 +36,7 @@ export function MobileStickyBar({
   availableCurrencies,
 }: MobileStickyBarProps) {
   const rate = rateData?.rate;
-  const displayRate = rate !== undefined ? rate.toFixed(4) : "—";
+  const displayRate = formatRate(rate, "—");
   const bandSymbol = currentBand ? getBandIndicator(currentBand.level) : null;
 
   return (
@@ -67,7 +69,7 @@ export function MobileStickyBar({
                     key={code}
                     value={code}
                     textValue={code}
-                    disabled={code === toCurrency}
+                    disabled={!isSupportedRatePair(code, toCurrency)}
                   >
                     {code} - {name}
                   </SelectItem>
@@ -86,7 +88,7 @@ export function MobileStickyBar({
                     key={code}
                     value={code}
                     textValue={code}
-                    disabled={code === fromCurrency}
+                    disabled={!isSupportedRatePair(fromCurrency, code)}
                   >
                     {code} - {name}
                   </SelectItem>

--- a/src/lib/__tests__/browser-ai.test.ts
+++ b/src/lib/__tests__/browser-ai.test.ts
@@ -18,7 +18,7 @@ describe('generateTemplateInsight', () => {
     expect(result).toContain('31.98');
     expect(result).toContain('34.08');
     expect(result).toMatch(/\d+\.\d+%/);
-    expect(result).toMatch(/\d+ fewer THB/);
+    expect(result).toMatch(/[\d,.]+ fewer THB/);
   });
 
   test('says "below" when current rate is below mean', () => {

--- a/src/lib/__tests__/currency-api-gold.test.ts
+++ b/src/lib/__tests__/currency-api-gold.test.ts
@@ -1,0 +1,130 @@
+import {
+  fetchAvailableCurrencies,
+  fetchCurrentRate,
+  fetchRateHistory,
+  fetchRealTimeRate,
+} from '../currency-api';
+import { THAI_GOLD_XAU_FACTOR } from '../rate-assets';
+
+const mockFetch = jest.fn();
+
+function jsonResponse(data: unknown, ok = true, status = 200): Response {
+  return {
+    ok,
+    status,
+    json: jest.fn().mockResolvedValue(data),
+    text: jest.fn().mockResolvedValue(JSON.stringify(data)),
+  } as unknown as Response;
+}
+
+describe('gold rate routing', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    global.fetch = mockFetch;
+  });
+
+  test('keeps ordinary fiat pairs on Frankfurter v1', async () => {
+    mockFetch.mockResolvedValue(jsonResponse({
+      amount: 1,
+      base: 'USD',
+      date: '2026-07-18',
+      rates: { THB: 32.5 },
+    }));
+
+    const result = await fetchRealTimeRate('USD', 'THB');
+
+    expect(String(mockFetch.mock.calls[0][0])).toContain('/v1/latest?from=USD&to=THB');
+    expect(result).toMatchObject({ rate: 32.5, source: 'frankfurter', fromCurrency: 'USD', toCurrency: 'THB' });
+  });
+
+  test('adds both gold choices to the existing v1 currency catalog', async () => {
+    mockFetch.mockResolvedValue(jsonResponse({ USD: 'United States Dollar', THB: 'Thai Baht' }));
+
+    const result = await fetchAvailableCurrencies();
+
+    expect(String(mockFetch.mock.calls[0][0])).toContain('/v1/currencies');
+    expect(result).toMatchObject({
+      USD: 'United States Dollar',
+      THB: 'Thai Baht',
+      XAU: 'Gold (Troy Ounce)',
+      THG: 'Thai Gold 96.5% — 1 baht-weight (reference)',
+    });
+  });
+
+  test('parses a current XAU pair from Frankfurter v2', async () => {
+    mockFetch.mockResolvedValue(jsonResponse({
+      date: '2026-07-18',
+      base: 'XAU',
+      quote: 'THB',
+      rate: 140000,
+    }));
+
+    const result = await fetchRealTimeRate('XAU', 'THB');
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://api.frankfurter.dev/v2/rate/XAU/THB',
+      { cache: 'no-store' },
+    );
+    expect(result).toMatchObject({ rate: 140000, source: 'frankfurter-v2', date: '2026-07-18' });
+  });
+
+  test('derives THG in both directions and preserves inverse consistency', async () => {
+    mockFetch
+      .mockResolvedValueOnce(jsonResponse({ date: '2026-07-18', base: 'XAU', quote: 'THB', rate: 140000 }))
+      .mockResolvedValueOnce(jsonResponse({ date: '2026-07-18', base: 'XAU', quote: 'THB', rate: 140000 }));
+
+    const thgToThb = await fetchRealTimeRate('THG', 'THB');
+    const thbToThg = await fetchRealTimeRate('THB', 'THG');
+
+    expect(thgToThb?.rate).toBeCloseTo(140000 * THAI_GOLD_XAU_FACTOR, 8);
+    expect(thbToThg?.rate).toBeCloseTo((1 / 140000) / THAI_GOLD_XAU_FACTOR, 12);
+    expect((thgToThb?.rate ?? 0) * (thbToThg?.rate ?? 0)).toBeCloseTo(1, 10);
+    expect(thgToThb?.source).toBe('frankfurter-derived');
+    expect(thbToThg?.source).toBe('frankfurter-derived');
+    expect(mockFetch.mock.calls.map(call => String(call[0]))).toEqual([
+      'https://api.frankfurter.dev/v2/rate/XAU/THB',
+      'https://api.frankfurter.dev/v2/rate/XAU/THB',
+    ]);
+  });
+
+  test('preserves the legacy current-rate response shape for gold alerts', async () => {
+    mockFetch.mockResolvedValue(jsonResponse({ date: '2026-07-18', base: 'XAU', quote: 'THB', rate: 140000 }));
+
+    const result = await fetchCurrentRate('THG', 'THB');
+
+    expect(result).toEqual({
+      amount: 1,
+      base: 'THG',
+      date: '2026-07-18',
+      rates: { THB: 140000 * THAI_GOLD_XAU_FACTOR },
+    });
+  });
+
+  test('maps, scales, filters, and sorts v2 gold history', async () => {
+    mockFetch.mockResolvedValue(jsonResponse([
+      { date: '2026-07-03', base: 'XAU', quote: 'THB', rate: 141000 },
+      { date: '2026-07-01', base: 'XAU', quote: 'THB', rate: 140000 },
+      { date: '2026-07-02', base: 'XAU', quote: 'THB', rate: -1 },
+      { date: 'bad', base: 'XAU', quote: 'USD', rate: 4000 },
+    ]));
+
+    const result = await fetchRateHistory('THG', 'THB', 30);
+
+    expect(String(mockFetch.mock.calls[0][0])).toMatch(/\/v2\/rates\?base=XAU&quotes=THB&from=.*&to=.*/);
+    expect(result).toEqual([
+      { date: '2026-07-01', rate: 140000 * THAI_GOLD_XAU_FACTOR },
+      { date: '2026-07-03', rate: 141000 * THAI_GOLD_XAU_FACTOR },
+    ]);
+  });
+
+  test('fails closed for invalid gold pairs and malformed v2 payloads', async () => {
+    expect(await fetchRealTimeRate('XAU', 'THG')).toBeNull();
+    expect(mockFetch).not.toHaveBeenCalled();
+
+    mockFetch.mockResolvedValueOnce(jsonResponse({ date: '2026-07-18', base: 'XAU', quote: 'THB', rate: 0 }));
+    expect(await fetchRealTimeRate('XAU', 'THB')).toBeNull();
+
+    mockFetch.mockResolvedValueOnce(jsonResponse({ rates: [] }));
+    expect(await fetchRateHistory('XAU', 'THB', 30)).toEqual([]);
+  });
+});

--- a/src/lib/__tests__/rate-assets.test.ts
+++ b/src/lib/__tests__/rate-assets.test.ts
@@ -1,0 +1,60 @@
+import {
+  THAI_GOLD_XAU_FACTOR,
+  applyNormalizedGoldRate,
+  appendGoldAssets,
+  areEquivalentGoldAssets,
+  getCompatibleFallbackAsset,
+  normalizeGoldPair,
+} from '../rate-assets';
+
+describe('gold asset catalog', () => {
+  test('defines one Thai gold bar as its pure-gold XAU equivalent', () => {
+    expect(THAI_GOLD_XAU_FACTOR).toBeCloseTo(0.4729522714, 10);
+  });
+
+  test('appends international and Thai gold without replacing fiat assets', () => {
+    expect(appendGoldAssets({ USD: 'United States Dollar', THB: 'Thai Baht' })).toEqual({
+      USD: 'United States Dollar',
+      THB: 'Thai Baht',
+      XAU: 'Gold (Troy Ounce)',
+      THG: 'Thai Gold 96.5% — 1 baht-weight (reference)',
+    });
+  });
+
+  test('treats XAU and THG as an invalid same-underlying pair', () => {
+    expect(areEquivalentGoldAssets('XAU', 'THG')).toBe(true);
+    expect(areEquivalentGoldAssets('THG', 'XAU')).toBe(true);
+    expect(areEquivalentGoldAssets('XAU', 'THB')).toBe(false);
+  });
+
+  test('normalizes THG to XAU and applies the correct direction multiplier', () => {
+    expect(normalizeGoldPair('THG', 'THB')).toEqual({
+      apiFrom: 'XAU',
+      apiTo: 'THB',
+      multiplier: THAI_GOLD_XAU_FACTOR,
+      invert: false,
+      derived: true,
+    });
+    expect(normalizeGoldPair('THB', 'THG')).toEqual({
+      apiFrom: 'XAU',
+      apiTo: 'THB',
+      multiplier: 1 / THAI_GOLD_XAU_FACTOR,
+      invert: true,
+      derived: true,
+    });
+  });
+
+  test('inverts a high-magnitude XAU quote locally to preserve tiny-rate precision', () => {
+    const normalizedPair = normalizeGoldPair('THB', 'THG');
+    expect(applyNormalizedGoldRate(140000, normalizedPair)).toBeCloseTo(
+      1 / (140000 * THAI_GOLD_XAU_FACTOR),
+      12,
+    );
+  });
+
+  test('prefers THB then USD when replacing an incompatible counterpart', () => {
+    const currencies = { AUD: 'Australian Dollar', USD: 'United States Dollar', THB: 'Thai Baht', XAU: 'Gold', THG: 'Thai Gold' };
+    expect(getCompatibleFallbackAsset('XAU', currencies)).toBe('THB');
+    expect(getCompatibleFallbackAsset('THG', { AUD: 'Australian Dollar', USD: 'United States Dollar', XAU: 'Gold', THG: 'Thai Gold' })).toBe('USD');
+  });
+});

--- a/src/lib/__tests__/rate-format.test.ts
+++ b/src/lib/__tests__/rate-format.test.ts
@@ -1,0 +1,25 @@
+import { formatRate, getRateDecimalPlaces } from '../rate-format';
+
+describe('adaptive rate formatting', () => {
+  test.each([
+    [140123.456, '140,123.46'],
+    [4101.23456, '4,101.23'],
+    [32.123456, '32.1235'],
+    [0.03123456, '0.031235'],
+    [0.0000154321, '0.00001543'],
+  ])('formats %s without hiding meaningful precision', (value, expected) => {
+    expect(formatRate(value)).toBe(expected);
+  });
+
+  test('returns a stable placeholder for missing or invalid rates', () => {
+    expect(formatRate(null)).toBe('N/A');
+    expect(formatRate(Number.NaN)).toBe('N/A');
+  });
+
+  test('provides matching chart precision', () => {
+    expect(getRateDecimalPlaces(4101)).toBe(2);
+    expect(getRateDecimalPlaces(32)).toBe(4);
+    expect(getRateDecimalPlaces(0.03)).toBe(6);
+    expect(getRateDecimalPlaces(0.00001)).toBe(8);
+  });
+});

--- a/src/lib/browser-ai.ts
+++ b/src/lib/browser-ai.ts
@@ -1,5 +1,6 @@
 // src/lib/browser-ai.ts
 // Template-based rate insight generation from statistical data
+import { formatRate } from './rate-format';
 
 export function generateTemplateInsight(data: {
   from: string; to: string;
@@ -11,7 +12,7 @@ export function generateTemplateInsight(data: {
   const { from, to, currentRate, mean, median, min, max, trendSummary, sampleDays } = data;
   const diff = currentRate - mean;
   const pctDiff = Math.abs((diff / mean) * 100).toFixed(1);
-  const perHundred = Math.abs(diff * 100).toFixed(0);
+  const perHundred = formatRate(Math.abs(diff * 100));
   const isBelow = diff < 0;
   const sampleLabel = sampleDays ? `the ${sampleDays.toLocaleString()}-day average` : 'the historical average';
 
@@ -19,11 +20,11 @@ export function generateTemplateInsight(data: {
 
   if (isBelow) {
     lines.push(
-      `At ${currentRate.toFixed(2)} ${to} per ${from}, the rate is ${pctDiff}% below ${sampleLabel} of ${mean.toFixed(2)} — you'd get roughly ${perHundred} fewer ${to} for every 100 ${from} compared to typical rates.`
+      `At ${formatRate(currentRate)} ${to} per ${from}, the rate is ${pctDiff}% below ${sampleLabel} of ${formatRate(mean)} — you'd get roughly ${perHundred} fewer ${to} for every 100 ${from} compared to typical rates.`
     );
   } else {
     lines.push(
-      `At ${currentRate.toFixed(2)} ${to} per ${from}, the rate is ${pctDiff}% above ${sampleLabel} of ${mean.toFixed(2)} — you'd get roughly ${perHundred} more ${to} for every 100 ${from} compared to typical rates.`
+      `At ${formatRate(currentRate)} ${to} per ${from}, the rate is ${pctDiff}% above ${sampleLabel} of ${formatRate(mean)} — you'd get roughly ${perHundred} more ${to} for every 100 ${from} compared to typical rates.`
     );
   }
 
@@ -45,14 +46,14 @@ export function generateTemplateInsight(data: {
       );
     } else {
       lines.push(isBelow
-        ? `The rate has been relatively stable, so waiting may not help — ${median ? `rates above the median of ${median.toFixed(2)} ` : 'higher rates '}have been more common.`
-        : `The rate has been relatively stable near current levels — ${median ? `close to the median of ${median.toFixed(2)}` : 'a reasonable time to convert'}.`
+        ? `The rate has been relatively stable, so waiting may not help — ${median ? `rates above the median of ${formatRate(median)} ` : 'higher rates '}have been more common.`
+        : `The rate has been relatively stable near current levels — ${median ? `close to the median of ${formatRate(median)}` : 'a reasonable time to convert'}.`
       );
     }
   } else {
     lines.push(isBelow
-      ? `If you can wait for a rate closer to the average of ${mean.toFixed(2)}, you'd get more ${to} per ${from}.`
-      : `This is a favorable time to convert ${from} to ${to} — rates have been lower ${min ? `(as low as ${min.toFixed(2)})` : ''} in the past.`
+      ? `If you can wait for a rate closer to the average of ${formatRate(mean)}, you'd get more ${to} per ${from}.`
+      : `This is a favorable time to convert ${from} to ${to} — rates have been lower ${min ? `(as low as ${formatRate(min)})` : ''} in the past.`
     );
   }
 

--- a/src/lib/currency-api.ts
+++ b/src/lib/currency-api.ts
@@ -1,4 +1,12 @@
 import { fetchFrankfurterRate, FRANKFURTER_API_BASE_URL } from './frankfurter-api';
+import { fetchFrankfurterV2History, fetchFrankfurterV2Rate } from './frankfurter-v2-api';
+import {
+  appendGoldAssets,
+  applyNormalizedGoldRate,
+  isGoldAsset,
+  isSupportedRatePair,
+  normalizeGoldPair,
+} from './rate-assets';
 import { trackError } from './analytics';
 
 const API_BASE_URL = FRANKFURTER_API_BASE_URL;
@@ -18,7 +26,7 @@ export interface CurrentRateResponse {
 export interface RealTimeRateResponse {
   rate: number;
   timestamp: number;
-  source: 'frankfurter';
+  source: 'frankfurter' | 'frankfurter-v2' | 'frankfurter-derived';
   date: string;
   fromCurrency: string;
   toCurrency: string;
@@ -49,6 +57,17 @@ export interface MonthlyAggregatedRate {
 
 
 export async function fetchCurrentRate(from: string, to: string): Promise<CurrentRateResponse | null> {
+  if (isGoldAsset(from) || isGoldAsset(to)) {
+    const goldRate = await fetchRealTimeRate(from, to);
+    if (!goldRate) return null;
+    return {
+      amount: 1,
+      base: from,
+      date: goldRate.date,
+      rates: { [to]: goldRate.rate },
+    };
+  }
+
   try {
     // Add a cache-busting query parameter
     const timestamp = Date.now();
@@ -107,6 +126,26 @@ export async function fetchRealTimeRate(
   from: string,
   to: string
 ): Promise<RealTimeRateResponse | null> {
+  if (!isSupportedRatePair(from, to)) return null;
+
+  if (isGoldAsset(from) || isGoldAsset(to)) {
+    const normalizedPair = normalizeGoldPair(from, to);
+    const goldRate = await fetchFrankfurterV2Rate(
+      normalizedPair.apiFrom,
+      normalizedPair.apiTo,
+    );
+    if (!goldRate) return null;
+
+    return {
+      rate: applyNormalizedGoldRate(goldRate.rate, normalizedPair),
+      timestamp: new Date(`${goldRate.date}T00:00:00Z`).getTime(),
+      source: normalizedPair.derived ? 'frankfurter-derived' : 'frankfurter-v2',
+      date: goldRate.date,
+      fromCurrency: from,
+      toCurrency: to,
+    };
+  }
+
   // Use Frankfurter API (supports CORS, no auth needed)
   const apiRate = await fetchFrankfurterRate(from, to);
   if (apiRate) {
@@ -128,6 +167,8 @@ function formatDateForApi(date: Date): string {
 }
 
 export async function fetchRateHistory(from: string, to: string, days: number = 90): Promise<FormattedHistoricalRate[]> {
+  if (!isSupportedRatePair(from, to)) return [];
+
   const today = new Date();
   let startDate: string;
 
@@ -145,6 +186,20 @@ export async function fetchRateHistory(from: string, to: string, days: number = 
   if (new Date(startDate) > new Date(endDate)) {
     console.warn(`Start date ${startDate} is after end date ${endDate} for ${from}-${to}. Returning empty history.`);
     return [];
+  }
+
+  if (isGoldAsset(from) || isGoldAsset(to)) {
+    const normalizedPair = normalizeGoldPair(from, to);
+    const history = await fetchFrankfurterV2History(
+      normalizedPair.apiFrom,
+      normalizedPair.apiTo,
+      startDate,
+      endDate,
+    );
+    return history.map(({ date, rate }) => ({
+      date,
+      rate: applyNormalizedGoldRate(rate, normalizedPair),
+    }));
   }
   
   const apiUrl = `${API_BASE_URL}/${startDate}..${endDate}?from=${from}&to=${to}`;
@@ -280,7 +335,7 @@ export async function fetchAvailableCurrencies(): Promise<{ [key: string]: strin
         return null;
       }
     }
-    return data as { [key: string]: string };
+    return appendGoldAssets(data as { [key: string]: string });
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Unknown error';
     console.error("Generic error fetching available currencies:", error);

--- a/src/lib/dynamic-analysis.ts
+++ b/src/lib/dynamic-analysis.ts
@@ -1,6 +1,7 @@
 // src/lib/dynamic-analysis.ts
 
 import { fetchRateHistory, FormattedHistoricalRate } from './currency-api';
+import { formatRate } from './rate-format';
 
 // Define a type similar to the structure of full_analysis.json
 // This will be the return type of our main analysis function.
@@ -130,17 +131,17 @@ function generateTrendSummary(
     const lastRate = rates[rates.length - 1].rate;
     const firstDate = rates[0].date;
     const lastDate = rates[rates.length - 1].date;
-    let desc = `Rate changed from ${firstRate.toFixed(4)} to ${lastRate.toFixed(4)}.`;
+    let desc = `Rate changed from ${formatRate(firstRate)} to ${formatRate(lastRate)}.`;
 
     // Check for stability (e.g., less than 1% change)
     if (Math.abs(firstRate - lastRate) < firstRate * 0.01) {
-      desc = `Rate remained relatively stable around ${firstRate.toFixed(4)}.`;
+      desc = `Rate remained relatively stable around ${formatRate(firstRate)}.`;
     } else if (lastRate > firstRate) {
       const percChange = ((lastRate - firstRate) / firstRate) * 100;
-      desc = `Rate increased by ${percChange.toFixed(1)}% from ${firstRate.toFixed(4)} to ${lastRate.toFixed(4)}.`;
+      desc = `Rate increased by ${percChange.toFixed(1)}% from ${formatRate(firstRate)} to ${formatRate(lastRate)}.`;
     } else {
       const percChange = ((firstRate - lastRate) / firstRate) * 100; // Positive value for decrease
-      desc = `Rate decreased by ${percChange.toFixed(1)}% from ${firstRate.toFixed(4)} to ${lastRate.toFixed(4)}.`;
+      desc = `Rate decreased by ${percChange.toFixed(1)}% from ${formatRate(firstRate)} to ${formatRate(lastRate)}.`;
     }
     return [{ period: `${firstDate} to ${lastDate}`, description: desc }];
   }
@@ -179,16 +180,16 @@ function generateTrendSummary(
     let description = '';
 
     if (previousSegmentAvgRate === null) {
-      description = `Initial period average rate around ${currentSegmentAvgRate.toFixed(4)}.`;
+      description = `Initial period average rate around ${formatRate(currentSegmentAvgRate)}.`;
     } else {
       // Calculate percentage change relative to the previous segment's average
       const changePercent = ((currentSegmentAvgRate - previousSegmentAvgRate) / previousSegmentAvgRate) * 100;
       if (Math.abs(changePercent) < 2) { // Less than 2% change considered stable
-        description = `Remained relatively stable from previous period, average ${currentSegmentAvgRate.toFixed(4)}.`;
+        description = `Remained relatively stable from previous period, average ${formatRate(currentSegmentAvgRate)}.`;
       } else if (changePercent > 0) {
-        description = `Rose by ${changePercent.toFixed(1)}% from previous period to an average of ${currentSegmentAvgRate.toFixed(4)}.`;
+        description = `Rose by ${changePercent.toFixed(1)}% from previous period to an average of ${formatRate(currentSegmentAvgRate)}.`;
       } else { // changePercent < 0
-        description = `Fell by ${Math.abs(changePercent).toFixed(1)}% from previous period to an average of ${currentSegmentAvgRate.toFixed(4)}.`;
+        description = `Fell by ${Math.abs(changePercent).toFixed(1)}% from previous period to an average of ${formatRate(currentSegmentAvgRate)}.`;
       }
     }
     trendPeriods.push({ period: periodStr, description });

--- a/src/lib/frankfurter-v2-api.ts
+++ b/src/lib/frankfurter-v2-api.ts
@@ -1,0 +1,90 @@
+export const FRANKFURTER_V2_API_BASE_URL = 'https://api.frankfurter.dev/v2';
+
+interface FrankfurterV2Rate {
+  date: string;
+  base: string;
+  quote: string;
+  rate: number;
+}
+
+const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+function isValidRate(
+  value: unknown,
+  expectedBase: string,
+  expectedQuote: string,
+): value is FrankfurterV2Rate {
+  if (!value || typeof value !== 'object') return false;
+  const rate = value as Partial<FrankfurterV2Rate>;
+  return (
+    rate.base === expectedBase &&
+    rate.quote === expectedQuote &&
+    typeof rate.date === 'string' &&
+    ISO_DATE_PATTERN.test(rate.date) &&
+    typeof rate.rate === 'number' &&
+    Number.isFinite(rate.rate) &&
+    rate.rate > 0
+  );
+}
+
+export async function fetchFrankfurterV2Rate(
+  from: string,
+  to: string,
+): Promise<FrankfurterV2Rate | null> {
+  try {
+    const response = await fetch(`${FRANKFURTER_V2_API_BASE_URL}/rate/${from}/${to}`, {
+      cache: 'no-store',
+    });
+    if (!response.ok) {
+      console.warn(`Frankfurter v2 failed: ${response.status} for ${from}/${to}`);
+      return null;
+    }
+
+    const data: unknown = await response.json();
+    if (!isValidRate(data, from, to)) {
+      console.warn(`Invalid Frankfurter v2 rate for ${from}/${to}`);
+      return null;
+    }
+    return data;
+  } catch (error) {
+    console.error(`Frankfurter v2 fetch error for ${from}/${to}:`, error);
+    return null;
+  }
+}
+
+export async function fetchFrankfurterV2History(
+  from: string,
+  to: string,
+  startDate: string,
+  endDate: string,
+): Promise<FrankfurterV2Rate[]> {
+  const params = new URLSearchParams({
+    base: from,
+    quotes: to,
+    from: startDate,
+    to: endDate,
+  });
+
+  try {
+    const response = await fetch(`${FRANKFURTER_V2_API_BASE_URL}/rates?${params.toString()}`, {
+      cache: 'no-store',
+    });
+    if (!response.ok) {
+      console.warn(`Frankfurter v2 history failed: ${response.status} for ${from}/${to}`);
+      return [];
+    }
+
+    const data: unknown = await response.json();
+    if (!Array.isArray(data)) {
+      console.warn(`Invalid Frankfurter v2 history for ${from}/${to}`);
+      return [];
+    }
+
+    return data
+      .filter((item): item is FrankfurterV2Rate => isValidRate(item, from, to))
+      .sort((a, b) => a.date.localeCompare(b.date));
+  } catch (error) {
+    console.error(`Frankfurter v2 history fetch error for ${from}/${to}:`, error);
+    return [];
+  }
+}

--- a/src/lib/rate-assets.ts
+++ b/src/lib/rate-assets.ts
@@ -1,0 +1,120 @@
+export const THAI_GOLD_BAR_WEIGHT_GRAMS = 15.244;
+export const THAI_GOLD_PURITY = 0.965;
+export const TROY_OUNCE_GRAMS = 31.1034768;
+export const THAI_GOLD_XAU_FACTOR =
+  (THAI_GOLD_BAR_WEIGHT_GRAMS * THAI_GOLD_PURITY) / TROY_OUNCE_GRAMS;
+
+export interface RateAssetDefinition {
+  code: string;
+  name: string;
+  family: 'fiat' | 'gold';
+  unit: string;
+  apiCode: string;
+  xauPerUnit?: number;
+  derived?: boolean;
+}
+
+export const GOLD_ASSETS: Record<'XAU' | 'THG', RateAssetDefinition> = {
+  XAU: {
+    code: 'XAU',
+    name: 'Gold (Troy Ounce)',
+    family: 'gold',
+    unit: '1 troy ounce',
+    apiCode: 'XAU',
+    xauPerUnit: 1,
+  },
+  THG: {
+    code: 'THG',
+    name: 'Thai Gold 96.5% — 1 baht-weight (reference)',
+    family: 'gold',
+    unit: '1 baht-weight (15.244 g at 96.5% purity)',
+    apiCode: 'XAU',
+    xauPerUnit: THAI_GOLD_XAU_FACTOR,
+    derived: true,
+  },
+};
+
+export const COMMON_RATE_ASSETS = [
+  { code: 'USD', name: 'US Dollar' },
+  { code: 'THB', name: 'Thai Baht' },
+  { code: 'EUR', name: 'Euro' },
+  { code: 'GBP', name: 'British Pound' },
+  { code: 'JPY', name: 'Japanese Yen' },
+  { code: 'SGD', name: 'Singapore Dollar' },
+  { code: 'AUD', name: 'Australian Dollar' },
+  { code: 'CHF', name: 'Swiss Franc' },
+  { code: GOLD_ASSETS.XAU.code, name: GOLD_ASSETS.XAU.name },
+  { code: GOLD_ASSETS.THG.code, name: GOLD_ASSETS.THG.name },
+] as const;
+
+export function isGoldAsset(code: string): code is keyof typeof GOLD_ASSETS {
+  return code === 'XAU' || code === 'THG';
+}
+
+export function appendGoldAssets(currencies: Record<string, string>): Record<string, string> {
+  return {
+    ...currencies,
+    XAU: GOLD_ASSETS.XAU.name,
+    THG: GOLD_ASSETS.THG.name,
+  };
+}
+
+export function areEquivalentGoldAssets(from: string, to: string): boolean {
+  return isGoldAsset(from) && isGoldAsset(to) && from !== to;
+}
+
+export function isSupportedRatePair(from: string, to: string): boolean {
+  return Boolean(from && to && from !== to && !areEquivalentGoldAssets(from, to));
+}
+
+export function getCompatibleFallbackAsset(
+  selectedCode: string,
+  currencies: Record<string, string>,
+): string | undefined {
+  const candidates = ['THB', 'USD', ...Object.keys(currencies)];
+  return candidates.find(
+    (candidate, index) =>
+      candidates.indexOf(candidate) === index &&
+      Boolean(currencies[candidate]) &&
+      isSupportedRatePair(selectedCode, candidate),
+  );
+}
+
+export interface NormalizedGoldPair {
+  apiFrom: string;
+  apiTo: string;
+  multiplier: number;
+  invert: boolean;
+  derived: boolean;
+}
+
+export function normalizeGoldPair(from: string, to: string): NormalizedGoldPair {
+  const fromAsset = isGoldAsset(from) ? GOLD_ASSETS[from] : null;
+  const toAsset = isGoldAsset(to) ? GOLD_ASSETS[to] : null;
+
+  if (toAsset && !fromAsset) {
+    return {
+      apiFrom: 'XAU',
+      apiTo: from,
+      multiplier: 1 / (toAsset.xauPerUnit ?? 1),
+      invert: true,
+      derived: Boolean(toAsset.derived),
+    };
+  }
+
+  return {
+    apiFrom: fromAsset?.apiCode ?? from,
+    apiTo: toAsset?.apiCode ?? to,
+    multiplier: (fromAsset?.xauPerUnit ?? 1) / (toAsset?.xauPerUnit ?? 1),
+    invert: false,
+    derived: Boolean(fromAsset?.derived || toAsset?.derived),
+  };
+}
+
+export function applyNormalizedGoldRate(
+  rate: number,
+  normalizedPair: NormalizedGoldPair,
+): number {
+  const orientedRate = normalizedPair.invert ? 1 / rate : rate;
+  return orientedRate * normalizedPair.multiplier;
+}

--- a/src/lib/rate-checker.ts
+++ b/src/lib/rate-checker.ts
@@ -1,5 +1,6 @@
 import { fetchRealTimeRate } from './currency-api';
 import type { RateAlert, AlertCheckResult } from './alerts-types';
+import { formatRate } from './rate-format';
 
 /**
  * Check a single alert against the current rate via Frankfurter API
@@ -71,9 +72,9 @@ export function formatAlertCheckResult(result: AlertCheckResult): string {
   const pair = `${alert.fromCurrency}/${alert.toCurrency}`;
 
   if (triggered) {
-    return `🔔 Alert triggered! ${pair} is ${currentRate.toFixed(2)} (${alert.condition} ${alert.threshold.toFixed(2)})`;
+    return `🔔 Alert triggered! ${pair} is ${formatRate(currentRate)} (${alert.condition} ${formatRate(alert.threshold)})`;
   }
 
   const direction = alert.condition === 'above' ? 'below' : 'above';
-  return `ℹ️ ${pair} is ${currentRate.toFixed(2)}, still ${direction} your target of ${alert.threshold.toFixed(2)}`;
+  return `ℹ️ ${pair} is ${formatRate(currentRate)}, still ${direction} your target of ${formatRate(alert.threshold)}`;
 }

--- a/src/lib/rate-format.ts
+++ b/src/lib/rate-format.ts
@@ -1,0 +1,22 @@
+export function getRateDecimalPlaces(value: number): number {
+  const absoluteValue = Math.abs(value);
+  if (absoluteValue >= 1000) return 2;
+  if (absoluteValue >= 1) return 4;
+  if (absoluteValue >= 0.01) return 6;
+  return 8;
+}
+
+export function formatRate(
+  value: number | null | undefined,
+  fallback = 'N/A',
+): string {
+  if (value === null || value === undefined || !Number.isFinite(value)) {
+    return fallback;
+  }
+
+  const decimals = getRateDecimalPlaces(value);
+  return new Intl.NumberFormat('en-US', {
+    minimumFractionDigits: decimals,
+    maximumFractionDigits: decimals,
+  }).format(value);
+}


### PR DESCRIPTION
## Summary

- add XAU current/history support through Frankfurter v2 while keeping fiat pairs on v1
- add derived THG reference pricing for one 96.5% Thai gold baht-weight, with explicit non-retail disclosure
- share gold assets across desktop/mobile selectors and browser alerts, block XAU/THG pairing, and add adaptive rate precision
- fail closed on malformed or unavailable v2 data

## Verification

- npm test -- --runInBand: 46 tests passed
- npm run typecheck: passed
- npm run build: passed, 25 static pages generated
- live Frankfurter v2: XAU/THB current 134794 on 2026-07-20; 20 July history points returned
- Playwright desktop/mobile: XAU and THG dashboard, chart, analysis, disclosures, disabled equivalent pair, and THG alert refresh verified with zero console errors
- inverse THB/THG precision verified at 0.00001569 by inverting the high-magnitude XAU/THB quote locally

No merge performed.