### PR TITLE
fix: deduplicate historical rate requests

### DIFF
--- a/src/app/__tests__/page-analysis-race.test.tsx
+++ b/src/app/__tests__/page-analysis-race.test.tsx
@@ -1,0 +1,176 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import UsdThbMonitorPage from '../page';
+import { generatePairAnalysis, type PairAnalysisData } from '@/lib/dynamic-analysis';
+
+jest.mock('@/lib/dynamic-analysis', () => ({
+  generatePairAnalysis: jest.fn(),
+}));
+
+jest.mock('@/lib/analytics', () => ({
+  trackAffiliateClick: jest.fn(),
+  trackBandRecommendation: jest.fn(),
+  trackCurrencyChange: jest.fn(),
+  trackAnalysisPeriodChange: jest.fn(),
+}));
+
+jest.mock('@/hooks/use-local-storage', () => ({
+  useLocalStorage: (_key: string, initialValue: unknown) => [initialValue, jest.fn()],
+}));
+
+jest.mock('next/link', () => {
+  const React = jest.requireActual('react');
+  return {
+    __esModule: true,
+    default: ({ children, ...props }: { children?: ReactNode; [key: string]: unknown }) =>
+      React.createElement('a', props, children),
+  };
+});
+
+jest.mock('lucide-react', () => {
+  const Icon = () => null;
+  return {
+    Award: Icon,
+    ChevronDown: Icon,
+    ExternalLink: Icon,
+    TrendingUp: Icon,
+  };
+});
+
+jest.mock('@/components/current-rate-display', () => {
+  const React = jest.requireActual('react');
+  return {
+    __esModule: true,
+    default: ({ onFromCurrencyChange }: { onFromCurrencyChange: (currency: string) => void }) =>
+      React.createElement(
+        'button',
+        { 'data-testid': 'change-pair', onClick: () => onFromCurrencyChange('EUR') },
+        'Change pair',
+      ),
+  };
+});
+
+jest.mock('@/components/history-chart-display', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock('@/components/analysis-display', () => {
+  const React = jest.requireActual('react');
+  return {
+    __esModule: true,
+    default: ({ pairAnalysisData }: { pairAnalysisData: PairAnalysisData | null }) =>
+      React.createElement(
+        'div',
+        { 'data-testid': 'analysis-data' },
+        String(pairAnalysisData?.distribution_statistics.mean ?? 'empty'),
+      ),
+  };
+});
+
+jest.mock('@/components/mobile-sticky-bar', () => ({
+  __esModule: true,
+  MobileStickyBar: () => null,
+}));
+
+jest.mock('@/components/hero-band-card', () => ({
+  __esModule: true,
+  HeroBandCard: () => null,
+}));
+
+jest.mock('@/components/ui/label', () => {
+  const React = jest.requireActual('react');
+  return { Label: ({ children }: { children?: ReactNode }) => React.createElement('label', null, children) };
+});
+
+jest.mock('@/components/ui/select', () => {
+  const React = jest.requireActual('react');
+  const passthrough = ({ children }: { children?: ReactNode }) =>
+    React.createElement(React.Fragment, null, children);
+  return {
+    Select: passthrough,
+    SelectContent: passthrough,
+    SelectItem: ({ children }: { children?: ReactNode }) => React.createElement('div', null, children),
+    SelectTrigger: passthrough,
+    SelectValue: () => null,
+  };
+});
+
+const mockGeneratePairAnalysis = generatePairAnalysis as jest.MockedFunction<typeof generatePairAnalysis>;
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>(resolvePromise => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+function makeAnalysis(mean: number): PairAnalysisData {
+  return {
+    trend_summary: [],
+    distribution_statistics: {
+      mean,
+      median: mean,
+      stdDev: 0,
+      min: mean,
+      max: mean,
+      p10: mean,
+      p25: mean,
+      p75: mean,
+      p90: mean,
+      sample_days: 1,
+      sample_period: '2026-07-18 to 2026-07-18',
+    },
+    threshold_bands: [],
+  };
+}
+
+async function assertStaleAnalysisIgnored(change: () => void, expectedArgs: [string, string, number]) {
+  const oldRequest = deferred<PairAnalysisData | null>();
+  const nextRequest = deferred<PairAnalysisData | null>();
+  mockGeneratePairAnalysis
+    .mockReturnValueOnce(oldRequest.promise)
+    .mockReturnValueOnce(nextRequest.promise);
+
+  render(<UsdThbMonitorPage />);
+  await waitFor(() => expect(mockGeneratePairAnalysis).toHaveBeenCalledTimes(1));
+
+  await act(async () => {
+    change();
+  });
+  await waitFor(() => expect(mockGeneratePairAnalysis).toHaveBeenCalledTimes(2));
+  expect(mockGeneratePairAnalysis).toHaveBeenNthCalledWith(2, ...expectedArgs);
+
+  await act(async () => {
+    oldRequest.resolve(makeAnalysis(1));
+    await oldRequest.promise;
+  });
+  expect(screen.getAllByTestId('analysis-data').every(element => element.textContent === 'empty')).toBe(true);
+
+  await act(async () => {
+    nextRequest.resolve(makeAnalysis(2));
+    await nextRequest.promise;
+  });
+  expect(screen.getAllByTestId('analysis-data').every(element => element.textContent === '2')).toBe(true);
+}
+
+describe('home-page analysis stale-response protection', () => {
+  beforeEach(() => {
+    mockGeneratePairAnalysis.mockReset();
+  });
+
+  test('ignores an old analysis after the pair changes', async () => {
+    await assertStaleAnalysisIgnored(
+      () => fireEvent.click(screen.getByTestId('change-pair')),
+      ['EUR', 'THB', 365 * 5],
+    );
+  });
+
+  test('ignores an old analysis after the period changes', async () => {
+    await assertStaleAnalysisIgnored(
+      () => fireEvent.click(screen.getByRole('button', { name: '3 Years' })),
+      ['USD', 'THB', 365 * 3],
+    );
+  });
+});

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -69,8 +69,11 @@ const UsdThbMonitorPage: FC = () => {
   }, []);
 
   const [pairAnalysisData, setPairAnalysisData] = useState<PairAnalysisData | null>(null);
+  const [pairAnalysisRequestKey, setPairAnalysisRequestKey] = useState<string | null>(null);
   const [isAnalysisLoading, setIsAnalysisLoading] = useState<boolean>(true);
   const [analysisError, setAnalysisError] = useState<string | null>(null);
+  const analysisRequestKey = `${selectedFromCurrency}|${selectedToCurrency}|${selectedPeriodDays}`;
+  const activePairAnalysisData = pairAnalysisRequestKey === analysisRequestKey ? pairAnalysisData : null;
 
   // Mobile layout state — lifted from CurrentRateDisplay
   const [mobileRateData, setMobileRateData] = useState<RealTimeRateResponse | null>(null);
@@ -78,39 +81,51 @@ const UsdThbMonitorPage: FC = () => {
   const [mobileCurrencies, setMobileCurrencies] = useState<Record<string, string> | null>(null);
 
   useEffect(() => {
+    let isCurrentRequest = true;
+
     const loadPairAnalysis = async () => {
       if (!selectedFromCurrency || !selectedToCurrency) {
         setAnalysisError("Please select both 'from' and 'to' currencies.");
         setIsAnalysisLoading(false);
         setPairAnalysisData(null);
+        setPairAnalysisRequestKey(null);
         return;
       }
 
       setIsAnalysisLoading(true);
       setAnalysisError(null);
       setPairAnalysisData(null);
+      setPairAnalysisRequestKey(null);
 
       try {
         const data = await generatePairAnalysis(selectedFromCurrency, selectedToCurrency, selectedPeriodDays);
+        if (!isCurrentRequest) return;
+
         if (data) {
           setPairAnalysisData(data);
+          setPairAnalysisRequestKey(analysisRequestKey);
         } else {
           setAnalysisError('No analysis data could be generated for the selected pair.');
         }
       } catch (e: any) {
+        if (!isCurrentRequest) return;
         setAnalysisError(`Failed to generate analysis: ${e.message || 'Unknown error'}`);
       } finally {
-        setIsAnalysisLoading(false);
+        if (isCurrentRequest) setIsAnalysisLoading(false);
       }
     };
 
     loadPairAnalysis();
-  }, [selectedFromCurrency, selectedToCurrency, selectedPeriodDays]);
+
+    return () => {
+      isCurrentRequest = false;
+    };
+  }, [selectedFromCurrency, selectedToCurrency, selectedPeriodDays, analysisRequestKey]);
 
   // Track band recommendation when analysis data is ready
   useEffect(() => {
-    if (pairAnalysisData?.threshold_bands && selectedFromCurrency && selectedToCurrency) {
-      const opportuneBand = pairAnalysisData.threshold_bands.find(
+    if (activePairAnalysisData?.threshold_bands && selectedFromCurrency && selectedToCurrency) {
+      const opportuneBand = activePairAnalysisData.threshold_bands.find(
         b => b.level === 'OPPORTUNE' || b.level === 'NEUTRAL'
       );
       if (opportuneBand) {
@@ -127,7 +142,7 @@ const UsdThbMonitorPage: FC = () => {
         );
       }
     }
-  }, [pairAnalysisData, selectedFromCurrency, selectedToCurrency]);
+  }, [activePairAnalysisData, selectedFromCurrency, selectedToCurrency]);
 
   return (
     <>
@@ -141,7 +156,7 @@ const UsdThbMonitorPage: FC = () => {
           toCurrency={selectedToCurrency}
           onFromCurrencyChange={handleFromCurrencyChange}
           onToCurrencyChange={handleToCurrencyChange}
-          pairAnalysisData={pairAnalysisData}
+          pairAnalysisData={activePairAnalysisData}
           onRateDataChange={setMobileRateData}
           onBandChange={setMobileCurrentBand}
           onCurrenciesChange={setMobileCurrencies}
@@ -153,8 +168,8 @@ const UsdThbMonitorPage: FC = () => {
           <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
             <div>
               <h3 className="text-lg font-semibold mb-1">
-                {pairAnalysisData?.distribution_statistics.mean
-                  ? `${selectedFromCurrency}/${selectedToCurrency} averages ${formatRate(pairAnalysisData.distribution_statistics.mean)}. Get notified when it hits your target.`
+                {activePairAnalysisData?.distribution_statistics.mean
+                  ? `${selectedFromCurrency}/${selectedToCurrency} averages ${formatRate(activePairAnalysisData.distribution_statistics.mean)}. Get notified when it hits your target.`
                   : 'Set rate alerts and get notified instantly'}
               </h3>
               <p className="text-sm text-primary-foreground/80">
@@ -219,7 +234,7 @@ const UsdThbMonitorPage: FC = () => {
             alertPrefs={alertPrefs}
             fromCurrency={selectedFromCurrency}
             toCurrency={selectedToCurrency}
-            pairAnalysisData={pairAnalysisData}
+            pairAnalysisData={activePairAnalysisData}
             selectedPeriodDays={selectedPeriodDays}
           />
 
@@ -234,7 +249,7 @@ const UsdThbMonitorPage: FC = () => {
                 fromCurrency={selectedFromCurrency}
                 toCurrency={selectedToCurrency}
                 currentRate={mobileRateData?.rate ?? null}
-                pairAnalysisData={pairAnalysisData}
+                pairAnalysisData={activePairAnalysisData}
                 isAnalysisLoading={isAnalysisLoading}
                 analysisError={analysisError}
               />
@@ -306,14 +321,14 @@ const UsdThbMonitorPage: FC = () => {
             alertPrefs={alertPrefs}
             fromCurrency={selectedFromCurrency}
             toCurrency={selectedToCurrency}
-            pairAnalysisData={pairAnalysisData}
+            pairAnalysisData={activePairAnalysisData}
             selectedPeriodDays={selectedPeriodDays}
           />
           <AnalysisDisplay
             fromCurrency={selectedFromCurrency}
             toCurrency={selectedToCurrency}
             currentRate={mobileRateData?.rate ?? null}
-            pairAnalysisData={pairAnalysisData}
+            pairAnalysisData={activePairAnalysisData}
             isAnalysisLoading={isAnalysisLoading}
             analysisError={analysisError}
           />

--- a/src/components/__tests__/history-chart-display-race.test.tsx
+++ b/src/components/__tests__/history-chart-display-race.test.tsx
@@ -4,6 +4,10 @@ import HistoryChartDisplay from '../history-chart-display';
 import { fetchRateHistory, type FormattedHistoricalRate } from '@/lib/currency-api';
 import { DEFAULT_ALERT_PREFS } from '@/lib/bands';
 
+type HistoryChartTestGlobal = typeof globalThis & {
+  __historyChartRenderedRates?: string[];
+};
+
 jest.mock('@/lib/currency-api', () => ({
   fetchRateHistory: jest.fn(),
 }));
@@ -31,11 +35,15 @@ jest.mock('recharts', () => {
   return {
     ResponsiveContainer: passthrough,
     LineChart: ({ data, children }: { data: FormattedHistoricalRate[]; children?: ReactNode }) =>
-      React.createElement(
-        'div',
-        { 'data-testid': 'history-chart', 'data-rates': data.map(point => point.rate).join(',') },
-        children,
-      ),
+      (() => {
+        const testGlobal = globalThis as HistoryChartTestGlobal;
+        (testGlobal.__historyChartRenderedRates ??= []).push(data.map(point => point.rate).join(','));
+        return React.createElement(
+          'div',
+          { 'data-testid': 'history-chart', 'data-rates': data.map(point => point.rate).join(',') },
+          children,
+        );
+      })(),
     Line: () => null,
     XAxis: () => null,
     YAxis: () => null,
@@ -59,9 +67,15 @@ const baseProps = {
   pairAnalysisData: null,
 };
 
+function renderedRates() {
+  const testGlobal = globalThis as HistoryChartTestGlobal;
+  return (testGlobal.__historyChartRenderedRates ??= []);
+}
+
 describe('HistoryChartDisplay stale history protection', () => {
   beforeEach(() => {
     mockFetchRateHistory.mockReset();
+    renderedRates().length = 0;
   });
 
   test.each([
@@ -112,5 +126,50 @@ describe('HistoryChartDisplay stale history protection', () => {
       await nextRequest.promise;
     });
     expect(screen.getByTestId('history-chart').getAttribute('data-rates')).toBe('2');
+  });
+
+  test.each([
+    { change: 'pair', nextFromCurrency: 'EUR', nextPeriodDays: 30 },
+    { change: 'period', nextFromCurrency: 'USD', nextPeriodDays: 60 },
+  ])('does not render the previous dataset during a $change change', async ({ nextFromCurrency, nextPeriodDays }) => {
+    const oldRequest = deferred<FormattedHistoricalRate[]>();
+    const nextRequest = deferred<FormattedHistoricalRate[]>();
+    mockFetchRateHistory
+      .mockReturnValueOnce(oldRequest.promise)
+      .mockReturnValueOnce(nextRequest.promise);
+
+    const { rerender } = render(
+      <HistoryChartDisplay
+        {...baseProps}
+        fromCurrency="USD"
+        toCurrency="THB"
+        selectedPeriodDays={30}
+      />,
+    );
+
+    await act(async () => {
+      oldRequest.resolve([{ date: '2026-07-17', rate: 1 }]);
+      await oldRequest.promise;
+    });
+    const rendersWithOldData = renderedRates().filter(rates => rates === '1').length;
+    expect(rendersWithOldData).toBeGreaterThan(0);
+
+    await act(async () => {
+      rerender(
+        <HistoryChartDisplay
+          {...baseProps}
+          fromCurrency={nextFromCurrency}
+          toCurrency="THB"
+          selectedPeriodDays={nextPeriodDays}
+        />,
+      );
+    });
+
+    expect(renderedRates().filter(rates => rates === '1')).toHaveLength(rendersWithOldData);
+
+    await act(async () => {
+      nextRequest.resolve([{ date: '2026-07-18', rate: 2 }]);
+      await nextRequest.promise;
+    });
   });
 });

--- a/src/components/__tests__/history-chart-display-race.test.tsx
+++ b/src/components/__tests__/history-chart-display-race.test.tsx
@@ -1,0 +1,116 @@
+import { act, render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import HistoryChartDisplay from '../history-chart-display';
+import { fetchRateHistory, type FormattedHistoricalRate } from '@/lib/currency-api';
+import { DEFAULT_ALERT_PREFS } from '@/lib/bands';
+
+jest.mock('@/lib/currency-api', () => ({
+  fetchRateHistory: jest.fn(),
+}));
+
+jest.mock('@/hooks/use-is-mobile', () => ({
+  useIsMobile: () => false,
+}));
+
+jest.mock('@/hooks/use-toast', () => ({
+  useToast: (() => {
+    const toast = jest.fn();
+    return () => ({ toast });
+  })(),
+}));
+
+jest.mock('lucide-react', () => ({
+  Loader2: () => null,
+}));
+
+jest.mock('recharts', () => {
+  const React = jest.requireActual('react');
+  const passthrough = ({ children }: { children?: ReactNode }) =>
+    React.createElement(React.Fragment, null, children);
+
+  return {
+    ResponsiveContainer: passthrough,
+    LineChart: ({ data, children }: { data: FormattedHistoricalRate[]; children?: ReactNode }) =>
+      React.createElement(
+        'div',
+        { 'data-testid': 'history-chart', 'data-rates': data.map(point => point.rate).join(',') },
+        children,
+      ),
+    Line: () => null,
+    XAxis: () => null,
+    YAxis: () => null,
+    Tooltip: () => null,
+    ReferenceArea: () => null,
+  };
+});
+
+const mockFetchRateHistory = fetchRateHistory as jest.MockedFunction<typeof fetchRateHistory>;
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>(resolvePromise => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+const baseProps = {
+  alertPrefs: DEFAULT_ALERT_PREFS,
+  pairAnalysisData: null,
+};
+
+describe('HistoryChartDisplay stale history protection', () => {
+  beforeEach(() => {
+    mockFetchRateHistory.mockReset();
+  });
+
+  test.each([
+    {
+      change: 'pair',
+      initial: { fromCurrency: 'USD', toCurrency: 'THB', selectedPeriodDays: 30 },
+      next: { fromCurrency: 'EUR', toCurrency: 'THB', selectedPeriodDays: 30 },
+    },
+    {
+      change: 'period',
+      initial: { fromCurrency: 'USD', toCurrency: 'THB', selectedPeriodDays: 30 },
+      next: { fromCurrency: 'USD', toCurrency: 'THB', selectedPeriodDays: 60 },
+    },
+  ])('does not render the old response after a $change change', async ({ initial, next }) => {
+    const oldRequest = deferred<FormattedHistoricalRate[]>();
+    const nextRequest = deferred<FormattedHistoricalRate[]>();
+    mockFetchRateHistory
+      .mockReturnValueOnce(oldRequest.promise)
+      .mockReturnValueOnce(nextRequest.promise);
+
+    const { rerender } = render(<HistoryChartDisplay {...baseProps} {...initial} />);
+
+    await act(async () => {
+      rerender(<HistoryChartDisplay {...baseProps} {...next} />);
+    });
+
+    expect(mockFetchRateHistory).toHaveBeenNthCalledWith(
+      1,
+      initial.fromCurrency,
+      initial.toCurrency,
+      initial.selectedPeriodDays,
+    );
+    expect(mockFetchRateHistory).toHaveBeenNthCalledWith(
+      2,
+      next.fromCurrency,
+      next.toCurrency,
+      next.selectedPeriodDays,
+    );
+
+    await act(async () => {
+      oldRequest.resolve([{ date: '2026-07-17', rate: 1 }]);
+      await oldRequest.promise;
+    });
+    expect(screen.queryByTestId('history-chart')).toBeNull();
+
+    await act(async () => {
+      nextRequest.resolve([{ date: '2026-07-18', rate: 2 }]);
+      await nextRequest.promise;
+    });
+    expect(screen.getByTestId('history-chart').getAttribute('data-rates')).toBe('2');
+  });
+});

--- a/src/components/history-chart-display.tsx
+++ b/src/components/history-chart-display.tsx
@@ -93,6 +93,7 @@ const HistoryChartDisplay: FC<HistoryChartDisplayProps> = ({
   const [chartDataRequestKey, setChartDataRequestKey] = useState<string | null>(null);
   const chartRequestKey = `${fromCurrency}|${toCurrency}|${selectedPeriodDays}`;
   const activeChartData = chartDataRequestKey === chartRequestKey ? chartData : [];
+  const hasValidPair = Boolean(fromCurrency && toCurrency && fromCurrency !== toCurrency);
 
   // Clear tapped point when dataset changes (currency pair or period)
   useEffect(() => {
@@ -107,6 +108,7 @@ const HistoryChartDisplay: FC<HistoryChartDisplayProps> = ({
     }
   }, [activeChartData]);
   const [isLoading, setIsLoading] = useState(false); // For historical data fetch
+  const isChartLoading = hasValidPair && (isLoading || chartDataRequestKey !== chartRequestKey);
   const { toast } = useToast();
   // const [selectedPeriod, setSelectedPeriod] = useState<string>("90"); // Remove internal period state
 
@@ -180,7 +182,7 @@ const HistoryChartDisplay: FC<HistoryChartDisplayProps> = ({
           setChartDataRequestKey(chartRequestKey);
         } else {
           setChartData([]);
-          setChartDataRequestKey(null);
+          setChartDataRequestKey(chartRequestKey);
           if (selectedPeriodDays !== 0) {
             toast({
               title: "No Data",
@@ -192,7 +194,10 @@ const HistoryChartDisplay: FC<HistoryChartDisplayProps> = ({
       } catch {
         // The history client fails closed. Keep this guard for unexpected errors
         // so a stale or rejected request cannot repopulate the chart.
-        if (isCurrentRequest) setChartData([]);
+        if (isCurrentRequest) {
+          setChartData([]);
+          setChartDataRequestKey(chartRequestKey);
+        }
       } finally {
         if (isCurrentRequest) setIsLoading(false);
       }
@@ -340,11 +345,11 @@ const HistoryChartDisplay: FC<HistoryChartDisplayProps> = ({
             )}
           </div>
         )}
-        {(isLoading && activeChartData.length === 0) ? (
+        {(isChartLoading && activeChartData.length === 0) ? (
           <div className="h-[350px] flex items-center justify-center">
             <Loader2 className="h-8 w-8 animate-spin text-primary" />
           </div>
-        ) : activeChartData.length === 0 && !isLoading ? (
+        ) : activeChartData.length === 0 && !isChartLoading ? (
           <div className="h-[350px] flex items-center justify-center text-muted-foreground text-center px-4">
             {fromCurrency && toCurrency && fromCurrency !== toCurrency ? 
               `No historical data to display for ${fromCurrency}/${toCurrency} for the selected period.` :

--- a/src/components/history-chart-display.tsx
+++ b/src/components/history-chart-display.tsx
@@ -90,6 +90,9 @@ const HistoryChartDisplay: FC<HistoryChartDisplayProps> = ({
   const isMobile = useIsMobile();
   const [tappedPoint, setTappedPoint] = useState<{ date: string; rate: number } | null>(null);
   const [chartData, setChartData] = useState<FormattedHistoricalRate[]>([]);
+  const [chartDataRequestKey, setChartDataRequestKey] = useState<string | null>(null);
+  const chartRequestKey = `${fromCurrency}|${toCurrency}|${selectedPeriodDays}`;
+  const activeChartData = chartDataRequestKey === chartRequestKey ? chartData : [];
 
   // Clear tapped point when dataset changes (currency pair or period)
   useEffect(() => {
@@ -98,15 +101,14 @@ const HistoryChartDisplay: FC<HistoryChartDisplayProps> = ({
 
   // Default tapped point to the latest data point for mobile
   useEffect(() => {
-    if (chartData.length > 0 && !tappedPoint) {
-      const last = chartData[chartData.length - 1];
+    if (activeChartData.length > 0 && !tappedPoint) {
+      const last = activeChartData[activeChartData.length - 1];
       setTappedPoint({ date: last.date, rate: last.rate });
     }
-  }, [chartData]);
+  }, [activeChartData]);
   const [isLoading, setIsLoading] = useState(false); // For historical data fetch
   const { toast } = useToast();
   // const [selectedPeriod, setSelectedPeriod] = useState<string>("90"); // Remove internal period state
-  const [chartBands, setChartBands] = useState<BandDefinition[]>([]); // For dynamic chart bands
 
   const handleChartClick = useCallback((payload: any) => {
     if (isMobile && payload && payload.activePayload && payload.activePayload.length > 0) {
@@ -124,8 +126,7 @@ const HistoryChartDisplay: FC<HistoryChartDisplayProps> = ({
   //   return parseInt(selectedPeriod, 10);
   // }, [selectedPeriod]);
 
-  // useEffect to process dynamic threshold_bands into chartBands
-  useEffect(() => {
+  const chartBands = useMemo(() => {
     if (pairAnalysisData?.threshold_bands) {
       const newChartBands = pairAnalysisData.threshold_bands.map((dynamicBand: DynamicThresholdBand): BandDefinition => {
         const bandName = mapLevelToBandName(dynamicBand.level);
@@ -147,10 +148,9 @@ const HistoryChartDisplay: FC<HistoryChartDisplayProps> = ({
           colorConfig: colorConfig,
         };
       });
-      setChartBands(newChartBands);
-    } else {
-      setChartBands([]); // No dynamic data, so no bands on chart or use a fallback
+      return newChartBands;
     }
+    return [];
   }, [pairAnalysisData]);
 
 
@@ -158,7 +158,7 @@ const HistoryChartDisplay: FC<HistoryChartDisplayProps> = ({
     let isCurrentRequest = true;
 
     setChartData([]);
-    setChartBands([]);
+    setChartDataRequestKey(null);
 
     if (!fromCurrency || !toCurrency || fromCurrency === toCurrency) {
       setIsLoading(false);
@@ -177,8 +177,10 @@ const HistoryChartDisplay: FC<HistoryChartDisplayProps> = ({
 
         if (data.length > 0) {
           setChartData(data);
+          setChartDataRequestKey(chartRequestKey);
         } else {
           setChartData([]);
+          setChartDataRequestKey(null);
           if (selectedPeriodDays !== 0) {
             toast({
               title: "No Data",
@@ -201,15 +203,15 @@ const HistoryChartDisplay: FC<HistoryChartDisplayProps> = ({
     return () => {
       isCurrentRequest = false;
     };
-  }, [selectedPeriodDays, fromCurrency, toCurrency, toast]); // Use selectedPeriodDays in dependency array
+  }, [selectedPeriodDays, fromCurrency, toCurrency, toast, chartRequestKey]); // Use selectedPeriodDays in dependency array
 
 
   const yAxisDomain = useMemo(() => {
     let minDataRate: number | undefined = undefined;
     let maxDataRate: number | undefined = undefined;
 
-    if (chartData && chartData.length > 0) {
-      const rates = chartData.map(d => d.rate);
+    if (activeChartData && activeChartData.length > 0) {
+      const rates = activeChartData.map(d => d.rate);
       minDataRate = Math.min(...rates);
       maxDataRate = Math.max(...rates);
     }
@@ -262,7 +264,7 @@ const HistoryChartDisplay: FC<HistoryChartDisplayProps> = ({
 
     return [parseFloat((overallMin - padding).toFixed(decimals)), parseFloat((overallMax + padding).toFixed(decimals))] as [number, number];
 
-  }, [chartData, chartBands, alertPrefs, fromCurrency, toCurrency]); // Depends on chartBands now
+  }, [activeChartData, chartBands, alertPrefs, fromCurrency, toCurrency]); // Depends on chartBands now
 
 
   const CustomTooltip: FC<any> = ({ active, payload, label }) => {
@@ -303,15 +305,15 @@ const HistoryChartDisplay: FC<HistoryChartDisplayProps> = ({
     else if (selectedPeriodDays === (365 * 10)) periodDesc = "10-Year Trend";
     else if (selectedPeriodDays === -1) { // Max Available
         const apiDefaultStartYear = "2000"; // Frankfurter API typical start
-        const startYear = chartData.length > 0 ? new Date(chartData[0].date).getFullYear() : apiDefaultStartYear;
-        const endYear = chartData.length > 0 ? new Date(chartData[chartData.length -1].date).getFullYear() : new Date().getFullYear();
-        if (chartData.length === 0 && startYear.toString() === apiDefaultStartYear) return `Historical Trend (${pair})`; // Generic if no data yet for max
+        const startYear = activeChartData.length > 0 ? new Date(activeChartData[0].date).getFullYear() : apiDefaultStartYear;
+        const endYear = activeChartData.length > 0 ? new Date(activeChartData[activeChartData.length -1].date).getFullYear() : new Date().getFullYear();
+        if (activeChartData.length === 0 && startYear.toString() === apiDefaultStartYear) return `Historical Trend (${pair})`; // Generic if no data yet for max
         periodDesc = `Trend (${startYear} - ${endYear})`;
     } else {
         periodDesc = `Custom Period Trend (${selectedPeriodDays} days)`; // Fallback for other day counts
     }
     return `${periodDesc} for ${pair}`;
-  }, [selectedPeriodDays, chartData, fromCurrency, toCurrency]); // Use selectedPeriodDays in dependency array
+  }, [selectedPeriodDays, activeChartData, fromCurrency, toCurrency]); // Use selectedPeriodDays in dependency array
 
   return (
     <Card className="overflow-hidden shadow-lg rounded-xl">
@@ -327,7 +329,7 @@ const HistoryChartDisplay: FC<HistoryChartDisplayProps> = ({
       </CardHeader>
       <CardContent className="pt-6 pb-2 bg-background">
         {/* Mobile: tap-to-inspect info bar */}
-        {isMobile && chartData && chartData.length > 0 && (
+        {isMobile && activeChartData.length > 0 && (
           <div className="flex justify-between items-center px-4 py-1 text-sm text-muted-foreground border-b border-border/40">
             <span className="text-xs">Tap chart to inspect</span>
             {tappedPoint && (
@@ -338,11 +340,11 @@ const HistoryChartDisplay: FC<HistoryChartDisplayProps> = ({
             )}
           </div>
         )}
-        {(isLoading && (!chartData || chartData.length === 0)) ? (
+        {(isLoading && activeChartData.length === 0) ? (
           <div className="h-[350px] flex items-center justify-center">
             <Loader2 className="h-8 w-8 animate-spin text-primary" />
           </div>
-        ) : (!chartData || chartData.length === 0) && !isLoading ? (
+        ) : activeChartData.length === 0 && !isLoading ? (
           <div className="h-[350px] flex items-center justify-center text-muted-foreground text-center px-4">
             {fromCurrency && toCurrency && fromCurrency !== toCurrency ? 
               `No historical data to display for ${fromCurrency}/${toCurrency} for the selected period.` :
@@ -351,7 +353,7 @@ const HistoryChartDisplay: FC<HistoryChartDisplayProps> = ({
           </div>
         ) : (
           <ResponsiveContainer width="100%" height={isMobile ? 200 : 350}>
-            <LineChart data={chartData} margin={{ top: 5, right: isMobile ? 10 : 30, left: isMobile ? 5 : 25, bottom: 5 }} onClick={isMobile ? handleChartClick : undefined}>
+            <LineChart data={activeChartData} margin={{ top: 5, right: isMobile ? 10 : 30, left: isMobile ? 5 : 25, bottom: 5 }} onClick={isMobile ? handleChartClick : undefined}>
               <XAxis
                 dataKey="date"
                 tickFormatter={(value) => {

--- a/src/components/history-chart-display.tsx
+++ b/src/components/history-chart-display.tsx
@@ -155,30 +155,52 @@ const HistoryChartDisplay: FC<HistoryChartDisplayProps> = ({
 
 
   useEffect(() => {
-    const fetchData = async () => {
-      if (!fromCurrency || !toCurrency || fromCurrency === toCurrency) {
-        setChartData([]);
-        setIsLoading(false);
-        return;
-      }
-      setIsLoading(true);
-      // Use selectedPeriodDays prop directly for fetching data
-      const data = await fetchRateHistory(fromCurrency, toCurrency, selectedPeriodDays);
-      if (data.length > 0) {
-        setChartData(data);
-      } else {
-        setChartData([]);
-        if (selectedPeriodDays !== 0 && fromCurrency && toCurrency && fromCurrency !== toCurrency) {
-          toast({
-            title: "No Data",
-            description: `No historical data found for ${fromCurrency}/${toCurrency} for the selected period.`,
-            variant: "default",
-          });
-        }
-      }
+    let isCurrentRequest = true;
+
+    setChartData([]);
+    setChartBands([]);
+
+    if (!fromCurrency || !toCurrency || fromCurrency === toCurrency) {
       setIsLoading(false);
+      return () => {
+        isCurrentRequest = false;
+      };
+    }
+
+    setIsLoading(true);
+
+    const fetchData = async () => {
+      try {
+        // Use selectedPeriodDays prop directly for fetching data
+        const data = await fetchRateHistory(fromCurrency, toCurrency, selectedPeriodDays);
+        if (!isCurrentRequest) return;
+
+        if (data.length > 0) {
+          setChartData(data);
+        } else {
+          setChartData([]);
+          if (selectedPeriodDays !== 0) {
+            toast({
+              title: "No Data",
+              description: `No historical data found for ${fromCurrency}/${toCurrency} for the selected period.`,
+              variant: "default",
+            });
+          }
+        }
+      } catch {
+        // The history client fails closed. Keep this guard for unexpected errors
+        // so a stale or rejected request cannot repopulate the chart.
+        if (isCurrentRequest) setChartData([]);
+      } finally {
+        if (isCurrentRequest) setIsLoading(false);
+      }
     };
+
     fetchData();
+
+    return () => {
+      isCurrentRequest = false;
+    };
   }, [selectedPeriodDays, fromCurrency, toCurrency, toast]); // Use selectedPeriodDays in dependency array
 
 

--- a/src/lib/__tests__/currency-api-gold.test.ts
+++ b/src/lib/__tests__/currency-api-gold.test.ts
@@ -1,4 +1,5 @@
 import {
+  clearRateHistoryCache,
   fetchAvailableCurrencies,
   fetchCurrentRate,
   fetchRateHistory,
@@ -21,6 +22,7 @@ describe('gold rate routing', () => {
   beforeEach(() => {
     mockFetch.mockReset();
     global.fetch = mockFetch;
+    clearRateHistoryCache();
   });
 
   test('keeps ordinary fiat pairs on Frankfurter v1', async () => {
@@ -115,6 +117,21 @@ describe('gold rate routing', () => {
       { date: '2026-07-01', rate: 140000 * THAI_GOLD_XAU_FACTOR },
       { date: '2026-07-03', rate: 141000 * THAI_GOLD_XAU_FACTOR },
     ]);
+  });
+
+  test('keeps XAU, THG, and inverse history conversions isolated in the cache', async () => {
+    mockFetch.mockResolvedValue(jsonResponse([
+      { date: '2026-07-01', base: 'XAU', quote: 'THB', rate: 140000 },
+    ]));
+
+    const xauToThb = await fetchRateHistory('XAU', 'THB', 30);
+    const thgToThb = await fetchRateHistory('THG', 'THB', 30);
+    const thbToThg = await fetchRateHistory('THB', 'THG', 30);
+
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+    expect(xauToThb[0].rate).toBe(140000);
+    expect(thgToThb[0].rate).toBeCloseTo(140000 * THAI_GOLD_XAU_FACTOR, 8);
+    expect(thbToThg[0].rate).toBeCloseTo((1 / 140000) / THAI_GOLD_XAU_FACTOR, 12);
   });
 
   test('fails closed for invalid gold pairs and malformed v2 payloads', async () => {

--- a/src/lib/__tests__/currency-api-history-cache.test.ts
+++ b/src/lib/__tests__/currency-api-history-cache.test.ts
@@ -3,6 +3,7 @@ import {
   clearRateHistoryCache,
   fetchRateHistory,
 } from '../currency-api';
+import { THAI_GOLD_XAU_FACTOR } from '../rate-assets';
 
 const mockFetch = jest.fn();
 
@@ -42,6 +43,25 @@ describe('historical rate request sharing', () => {
 
     expect(mockFetch).toHaveBeenCalledTimes(1);
     expect(chartData).toEqual(secondChartData);
+    expect(analysisData?.distribution_statistics.sample_days).toBe(2);
+  });
+
+  test('concurrent gold chart and analysis consumers issue one v2 request', async () => {
+    mockFetch.mockResolvedValue(jsonResponse([
+      { date: '2026-07-17', base: 'XAU', quote: 'THB', rate: 140000 },
+      { date: '2026-07-18', base: 'XAU', quote: 'THB', rate: 141000 },
+    ]));
+
+    const [chartData, analysisData, secondChartData] = await Promise.all([
+      fetchRateHistory('THG', 'THB', 30),
+      generatePairAnalysis('THG', 'THB', 30),
+      fetchRateHistory('THG', 'THB', 30),
+    ]);
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(String(mockFetch.mock.calls[0][0])).toContain('/v2/rates?base=XAU&quotes=THB');
+    expect(chartData).toEqual(secondChartData);
+    expect(chartData[0].rate).toBeCloseTo(140000 * THAI_GOLD_XAU_FACTOR, 8);
     expect(analysisData?.distribution_statistics.sample_days).toBe(2);
   });
 

--- a/src/lib/__tests__/currency-api-history-cache.test.ts
+++ b/src/lib/__tests__/currency-api-history-cache.test.ts
@@ -16,6 +16,14 @@ function jsonResponse(data: unknown, ok = true, status = 200): Response {
   } as unknown as Response;
 }
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>(resolvePromise => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
 describe('historical rate request sharing', () => {
   beforeEach(() => {
     mockFetch.mockReset();
@@ -87,6 +95,27 @@ describe('historical rate request sharing', () => {
 
     await expect(fetchRateHistory('USD', 'THB', 31)).resolves.toEqual([]);
     await expect(fetchRateHistory('USD', 'THB', 31)).resolves.toEqual([]);
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  test('does not let a cleared empty request evict its replacement', async () => {
+    const oldResponse = deferred<Response>();
+    mockFetch
+      .mockReturnValueOnce(oldResponse.promise)
+      .mockResolvedValueOnce(jsonResponse({
+        amount: 1,
+        base: 'USD',
+        rates: { '2026-07-18': { THB: 32.5 } },
+      }));
+
+    const staleRequest = fetchRateHistory('USD', 'THB', 30);
+    clearRateHistoryCache();
+    await fetchRateHistory('USD', 'THB', 30);
+
+    oldResponse.resolve(jsonResponse({ amount: 1, base: 'USD', rates: {} }));
+    await staleRequest;
+    await fetchRateHistory('USD', 'THB', 30);
 
     expect(mockFetch).toHaveBeenCalledTimes(2);
   });

--- a/src/lib/__tests__/currency-api-history-cache.test.ts
+++ b/src/lib/__tests__/currency-api-history-cache.test.ts
@@ -1,0 +1,73 @@
+import { generatePairAnalysis } from '../dynamic-analysis';
+import {
+  clearRateHistoryCache,
+  fetchRateHistory,
+} from '../currency-api';
+
+const mockFetch = jest.fn();
+
+function jsonResponse(data: unknown, ok = true, status = 200): Response {
+  return {
+    ok,
+    status,
+    json: jest.fn().mockResolvedValue(data),
+    text: jest.fn().mockResolvedValue(JSON.stringify(data)),
+  } as unknown as Response;
+}
+
+describe('historical rate request sharing', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    global.fetch = mockFetch;
+    clearRateHistoryCache();
+  });
+
+  test('concurrent chart and analysis consumers issue one request for a pair and period', async () => {
+    mockFetch.mockResolvedValue(jsonResponse({
+      amount: 1,
+      base: 'USD',
+      start_date: '2026-06-18',
+      end_date: '2026-07-18',
+      rates: {
+        '2026-07-17': { THB: 32.5 },
+        '2026-07-18': { THB: 32.6 },
+      },
+    }));
+
+    const [chartData, analysisData, secondChartData] = await Promise.all([
+      fetchRateHistory('USD', 'THB', 30),
+      generatePairAnalysis('USD', 'THB', 30),
+      fetchRateHistory('USD', 'THB', 30),
+    ]);
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(chartData).toEqual(secondChartData);
+    expect(analysisData?.distribution_statistics.sample_days).toBe(2);
+  });
+
+  test('does not reuse history across pair or period changes', async () => {
+    mockFetch.mockResolvedValue(jsonResponse({
+      amount: 1,
+      base: 'USD',
+      rates: { '2026-07-18': { THB: 32.5 } },
+    }));
+
+    await fetchRateHistory('USD', 'THB', 30);
+    await fetchRateHistory('USD', 'THB', 30);
+    await fetchRateHistory('USD', 'THB', 60);
+    await fetchRateHistory('EUR', 'THB', 30);
+
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+    expect(String(mockFetch.mock.calls[0][0])).not.toBe(String(mockFetch.mock.calls[1][0]));
+    expect(String(mockFetch.mock.calls[0][0])).not.toBe(String(mockFetch.mock.calls[2][0]));
+  });
+
+  test('fails closed and does not cache an upstream error', async () => {
+    mockFetch.mockResolvedValue(jsonResponse({ error: 'temporarily unavailable' }, false, 503));
+
+    await expect(fetchRateHistory('USD', 'THB', 31)).resolves.toEqual([]);
+    await expect(fetchRateHistory('USD', 'THB', 31)).resolves.toEqual([]);
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/lib/currency-api.ts
+++ b/src/lib/currency-api.ts
@@ -166,8 +166,33 @@ function formatDateForApi(date: Date): string {
   return date.toISOString().split("T")[0];
 }
 
-export async function fetchRateHistory(from: string, to: string, days: number = 90): Promise<FormattedHistoricalRate[]> {
-  if (!isSupportedRatePair(from, to)) return [];
+interface RateHistoryRequest {
+  from: string;
+  to: string;
+  startDate: string;
+  endDate: string;
+  isGold: boolean;
+  apiFrom: string;
+  apiTo: string;
+  multiplier: number;
+  invert: boolean;
+  derived: boolean;
+  cacheKey: string;
+}
+
+const rateHistoryCache = new Map<string, Promise<FormattedHistoricalRate[]>>();
+
+/** Clear shared history requests between isolated consumers or tests. */
+export function clearRateHistoryCache(): void {
+  rateHistoryCache.clear();
+}
+
+function createRateHistoryRequest(
+  from: string,
+  to: string,
+  days: number,
+): RateHistoryRequest | null {
+  if (!isSupportedRatePair(from, to)) return null;
 
   const today = new Date();
   let startDate: string;
@@ -175,34 +200,66 @@ export async function fetchRateHistory(from: string, to: string, days: number = 
   if (days === -1) { // "Since Inception"
     // Frankfurter API earliest date for many pairs is 1999-01-04, but use a slightly later common one
     // or make this dynamic if certain pairs have much later start dates.
-    startDate = "2000-01-01"; 
+    startDate = "2000-01-01";
   } else {
     const pastDate = new Date();
     pastDate.setDate(today.getDate() - days);
     startDate = formatDateForApi(pastDate);
   }
   const endDate = formatDateForApi(today);
-  
+
   if (new Date(startDate) > new Date(endDate)) {
     console.warn(`Start date ${startDate} is after end date ${endDate} for ${from}-${to}. Returning empty history.`);
-    return [];
+    return null;
   }
 
-  if (isGoldAsset(from) || isGoldAsset(to)) {
-    const normalizedPair = normalizeGoldPair(from, to);
-    const history = await fetchFrankfurterV2History(
+  const isGold = isGoldAsset(from) || isGoldAsset(to);
+  const normalizedPair = isGold
+    ? normalizeGoldPair(from, to)
+    : { apiFrom: from, apiTo: to, multiplier: 1, invert: false, derived: false };
+
+  return {
+    from,
+    to,
+    startDate,
+    endDate,
+    isGold,
+    apiFrom: normalizedPair.apiFrom,
+    apiTo: normalizedPair.apiTo,
+    multiplier: normalizedPair.multiplier,
+    invert: normalizedPair.invert,
+    derived: normalizedPair.derived,
+    // Include the normalized API pair, conversion direction, and explicit range so
+    // equivalent consumers share only data that can be transformed identically.
+    cacheKey: [
+      isGold ? 'v2' : 'v1',
       normalizedPair.apiFrom,
       normalizedPair.apiTo,
+      normalizedPair.multiplier,
+      normalizedPair.invert ? 'invert' : 'direct',
       startDate,
       endDate,
+    ].join('|'),
+  };
+}
+
+async function fetchRateHistoryUncached(
+  request: RateHistoryRequest,
+): Promise<FormattedHistoricalRate[]> {
+  if (request.isGold) {
+    const history = await fetchFrankfurterV2History(
+      request.apiFrom,
+      request.apiTo,
+      request.startDate,
+      request.endDate,
     );
     return history.map(({ date, rate }) => ({
       date,
-      rate: applyNormalizedGoldRate(rate, normalizedPair),
+      rate: applyNormalizedGoldRate(rate, request),
     }));
   }
-  
-  const apiUrl = `${API_BASE_URL}/${startDate}..${endDate}?from=${from}&to=${to}`;
+
+  const apiUrl = `${API_BASE_URL}/${request.startDate}..${request.endDate}?from=${request.from}&to=${request.to}`;
 
   try {
     const response = await fetch(
@@ -211,7 +268,7 @@ export async function fetchRateHistory(from: string, to: string, days: number = 
     );
     if (!response.ok) {
       console.error(
-        `Failed to fetch rate history for ${from}-${to} (HTTP status):`,
+        `Failed to fetch rate history for ${request.from}-${request.to} (HTTP status):`,
         response.status,
         await response.text().catch(() => "Could not read response text")
       );
@@ -223,7 +280,7 @@ export async function fetchRateHistory(from: string, to: string, days: number = 
       data = await response.json();
     } catch (jsonError) {
        console.error(
-        `Failed to parse JSON response for ${from}-${to} rate history:`,
+        `Failed to parse JSON response for ${request.from}-${request.to} rate history:`,
         jsonError,
         await response.text().catch(() => "Could not read response text (after JSON parse failure)")
       );
@@ -231,25 +288,25 @@ export async function fetchRateHistory(from: string, to: string, days: number = 
     }
 
     if (typeof data !== 'object' || data === null) {
-        console.warn(`API response for ${from}-${to} rate history was not a non-null object:`, data);
+        console.warn(`API response for ${request.from}-${request.to} rate history was not a non-null object:`, data);
         return [];
     }
     
     if (!data.rates || typeof data.rates !== 'object') {
-      console.error(`Invalid data format for ${from}-${to} rate history (missing rates object):`, data);
+      console.error(`Invalid data format for ${request.from}-${request.to} rate history (missing rates object):`, data);
       return [];
     }
     
     const historicalData = data as HistoricalRateResponse;
 
     if (Object.keys(historicalData.rates).length === 0) {
-      console.warn(`No historical rates returned for ${from}-${to} between ${startDate} and ${endDate}.`);
+      console.warn(`No historical rates returned for ${request.from}-${request.to} between ${request.startDate} and ${request.endDate}.`);
       return [];
     }
 
     const formattedData = Object.entries(historicalData.rates)
       .map(([date, rateData]) => {
-        const rateValue = rateData && typeof rateData[to] === 'number' ? rateData[to] : 0;
+        const rateValue = rateData && typeof rateData[request.to] === 'number' ? rateData[request.to] : 0;
         return {
           date,
           rate: rateValue,
@@ -261,10 +318,40 @@ export async function fetchRateHistory(from: string, to: string, days: number = 
     return formattedData;
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Unknown error';
-    console.error(`Error fetching ${from}-${to} rate history:`, error);
-    trackError(message, `fetchRateHistory:${from}-${to}`);
+    console.error(`Error fetching ${request.from}-${request.to} rate history:`, error);
+    trackError(message, `fetchRateHistory:${request.from}-${request.to}`);
     return [];
   }
+}
+
+export function fetchRateHistory(
+  from: string,
+  to: string,
+  days: number = 90,
+): Promise<FormattedHistoricalRate[]> {
+  const request = createRateHistoryRequest(from, to, days);
+  if (!request) return Promise.resolve([]);
+
+  const cachedRequest = rateHistoryCache.get(request.cacheKey);
+  if (cachedRequest) return cachedRequest;
+
+  const pendingRequest = fetchRateHistoryUncached(request)
+    .catch((error: unknown) => {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      console.error(`Unexpected error fetching ${from}-${to} rate history:`, error);
+      trackError(message, `fetchRateHistory:${from}-${to}`);
+      return [];
+    })
+    .then((history) => {
+      // Empty responses represent an unavailable or invalid upstream result. Do not
+      // cache them so a later attempt can recover, while concurrent callers still
+      // share this in-flight promise.
+      if (history.length === 0) rateHistoryCache.delete(request.cacheKey);
+      return history;
+    });
+
+  rateHistoryCache.set(request.cacheKey, pendingRequest);
+  return pendingRequest;
 }
 
 

--- a/src/lib/currency-api.ts
+++ b/src/lib/currency-api.ts
@@ -335,7 +335,8 @@ export function fetchRateHistory(
   const cachedRequest = rateHistoryCache.get(request.cacheKey);
   if (cachedRequest) return cachedRequest;
 
-  const pendingRequest = fetchRateHistoryUncached(request)
+  let pendingRequest: Promise<FormattedHistoricalRate[]>;
+  pendingRequest = fetchRateHistoryUncached(request)
     .catch((error: unknown) => {
       const message = error instanceof Error ? error.message : 'Unknown error';
       console.error(`Unexpected error fetching ${from}-${to} rate history:`, error);
@@ -346,7 +347,12 @@ export function fetchRateHistory(
       // Empty responses represent an unavailable or invalid upstream result. Do not
       // cache them so a later attempt can recover, while concurrent callers still
       // share this in-flight promise.
-      if (history.length === 0) rateHistoryCache.delete(request.cacheKey);
+      if (
+        history.length === 0 &&
+        rateHistoryCache.get(request.cacheKey) === pendingRequest
+      ) {
+        rateHistoryCache.delete(request.cacheKey);
+      }
       return history;
     });
 


### PR DESCRIPTION
## Summary

- Add a keyed in-flight/result cache for historical requests using the normalized API pair, conversion direction, and explicit date range.
- Keep fiat v1 requests and XAU/THG v2 normalization/conversion behavior unchanged.
- Ignore stale pair/period responses in the chart and analysis consumers, and fail closed without caching empty/error results.
- Add regression coverage for concurrent consumers, pair/period invalidation, gold conversions, malformed responses, and API failures.

Fixes #42

## Validation

- `npm test -- --runInBand --no-cache` — 50 tests passed.
- `npm run typecheck` — passed.
- `npm run build` — production export passed.
- Static preview network trace — one `https://api.frankfurter.dev/v1/2021-07-21..2026-07-20?from=USD&to=THB` history request on initial home-page load, alongside the expected catalog and current-rate requests.
